### PR TITLE
Bump library utility config changes

### DIFF
--- a/.github/workflows/call-code-checks.yml
+++ b/.github/workflows/call-code-checks.yml
@@ -3,7 +3,7 @@ on: pull_request
 jobs:
   library:
     # this hash is updated automatically, so if you're resolving a merge conflict, either hash is fine
-    uses: reformcollective/library/.github/workflows/code-checks.yml@4ab37d7693a9a94997be95fc84f3d3a5e962c51f
+    uses: reformcollective/library/.github/workflows/code-checks.yml@1ad3ae8b6363c287948127e048faf6adba5e5cc7
     secrets:
       SECRETS_JSON: ${{ toJSON(secrets) }}
     with:

--- a/.github/workflows/call-lighthouse.yml
+++ b/.github/workflows/call-lighthouse.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   library:
     # this hash is updated automatically, so if you're resolving a merge conflict, either hash is fine
-    uses: reformcollective/library/.github/workflows/lighthouse.yml@4ab37d7693a9a94997be95fc84f3d3a5e962c51f
+    uses: reformcollective/library/.github/workflows/lighthouse.yml@1ad3ae8b6363c287948127e048faf6adba5e5cc7
     secrets:
       SECRETS_JSON: ${{ toJSON(secrets) }}
     with:


### PR DESCRIPTION
## Summary
- bump the `library` submodule to the utility-config change in reformcollective/library#480
- pick up the smaller default `f` utility surface and changelog guidance for restoring removed helpers

## Validation
- pnpm --filter ./library test
- pnpm format
- pnpm lint
- pnpm typecheck
- pnpm build

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump library submodule and reusable workflow references to commit `1ad3ae8`
> Updates the `library` submodule pointer and both reusable workflow references in [call-code-checks.yml](.github/workflows/call-code-checks.yml) and [call-lighthouse.yml](.github/workflows/call-lighthouse.yml) from commit `4ab37d7` to `1ad3ae8`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 657d1a1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->