### PR TITLE
fix client boundary

### DIFF
--- a/.github/workflows/call-code-checks.yml
+++ b/.github/workflows/call-code-checks.yml
@@ -3,7 +3,7 @@ on: pull_request
 jobs:
   library:
     # this hash is updated automatically, so if you're resolving a merge conflict, either hash is fine
-    uses: reformcollective/library/.github/workflows/code-checks.yml@2a11bd228f0d22230b06ca87ab00b1ffe0ae4e72
+    uses: reformcollective/library/.github/workflows/code-checks.yml@087b5f208bc06d936a525df91246215fa732e9d3
     secrets:
       SECRETS_JSON: ${{ toJSON(secrets) }}
     with:

--- a/.github/workflows/call-lighthouse.yml
+++ b/.github/workflows/call-lighthouse.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   library:
     # this hash is updated automatically, so if you're resolving a merge conflict, either hash is fine
-    uses: reformcollective/library/.github/workflows/lighthouse.yml@2a11bd228f0d22230b06ca87ab00b1ffe0ae4e72
+    uses: reformcollective/library/.github/workflows/lighthouse.yml@087b5f208bc06d936a525df91246215fa732e9d3
     secrets:
       SECRETS_JSON: ${{ toJSON(secrets) }}
     with:

--- a/app/(blog-templates)/(blog-template-1)/[blogSlug]/(home)/BlogHomeClient.tsx
+++ b/app/(blog-templates)/(blog-template-1)/[blogSlug]/(home)/BlogHomeClient.tsx
@@ -47,7 +47,7 @@ export function BlogHomeClient({ allCards, featuredCaseStudy, searchMode }: Blog
 
 	// server-side search state
 	const [serverResults, setServerResults] = useState<Card[]>([])
-	const [isPending, startTransition] = useTransition()
+	const [, startTransition] = useTransition()
 
 	useHeaderTheme("dark")
 

--- a/app/[[...slug]]/page.tsx
+++ b/app/[[...slug]]/page.tsx
@@ -1,7 +1,7 @@
 import SampleSection from "app/sections/Sample"
 import { EagerImages } from "library/StaticImage"
 import { imageField, linkField, videoField } from "library/sanity/assetMetadata"
-import { createSanityDataAttribute } from "library/sanity/createSanityDataAttribute"
+import type { SanityDataAttributeContext } from "library/sanity/getSanityDataAttribute"
 import { resolveDocumentTitle, resolveProductionUrl } from "library/sanity/document-helpers"
 import { resolveOpenGraphImage } from "library/sanity/opengraph"
 import { Redirect } from "library/sanity/redirect"
@@ -19,7 +19,7 @@ type SectionTypes = PageSection["_type"]
 
 type WithExtraProps<T> = T & {
 	pageTitle: string
-	generateSanityDataAttribute: (property: keyof T) => string
+	sanityDataAttribute: SanityDataAttributeContext
 }
 
 export type GetSectionType<T extends SectionTypes> = WithExtraProps<
@@ -132,21 +132,13 @@ export default async function TemplatePage({ params }: PageProps<"/[[...slug]]">
 			{sections.map((section, index: number) => {
 				const Wrapper = index === 0 ? EagerImages : Fragment
 
-				/**
-				 * @param path path to the property on the object. for example, if you were rendering
-				 * mySection.myObject.myImage you would pass "myObject.myImage"
-				 * @returns the data attribute for the data-sanity prop
-				 */
-				const dataAttributeCreator = (path: string) =>
-					createSanityDataAttribute({
-						documentId: relevantPage._id,
-						documentType: relevantPage._type,
-						path: `sections[${index}].${path}`,
-					})
-
 				const sectionContext = {
 					pageTitle,
-					generateSanityDataAttribute: dataAttributeCreator,
+					sanityDataAttribute: {
+						documentId: relevantPage._id,
+						documentType: relevantPage._type,
+						pathPrefix: `sections[${index}]`,
+					},
 				}
 
 				switch (section._type) {

--- a/app/sections/Sample.tsx
+++ b/app/sections/Sample.tsx
@@ -1,4 +1,7 @@
+"use client"
+
 import type { GetSectionType } from "page"
+import { getSanityDataAttribute } from "library/sanity/getSanityDataAttribute"
 import { VideoEmbed } from "library/videos/VideoEmbed"
 import { sleep } from "library/functions"
 import { css, fresponsive, styled } from "library/styled"
@@ -7,7 +10,7 @@ export default async function SampleSection({
 	title,
 	text,
 	sampleVideo,
-	generateSanityDataAttribute,
+	sanityDataAttribute,
 }: GetSectionType<"sample">) {
 	/**
 	 * artificially delay so we can see the loading state
@@ -19,7 +22,9 @@ export default async function SampleSection({
 		<Wrapper>
 			<h1>{title}</h1>
 			<p>{text}</p>
-			<div data-sanity={generateSanityDataAttribute("title")}>example of a data sanity prop</div>
+			<div data-sanity={getSanityDataAttribute(sanityDataAttribute, "title")}>
+				example of a data sanity prop
+			</div>
 			{sampleVideo && <VideoEmbed video={sampleVideo} />}
 		</Wrapper>
 	)


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix client boundary in `SampleSection` by replacing `generateSanityDataAttribute` with a context object
- Converts [`app/sections/Sample.tsx`](https://github.com/reformcollective/reform-next-starter/pull/57/files#diff-5beba420515deadc4590f5e33680e18ba51ec9808ac21a5e30b96c2a30452f26) to a client component (`'use client'`) so it can call `getSanityDataAttribute` directly at render time.
- Replaces the `generateSanityDataAttribute` function prop with a `sanityDataAttribute` context object (`documentId`, `documentType`, `pathPrefix`) in the `WithExtraProps` type and in [`app/[[...slug]]/page.tsx`](https://github.com/reformcollective/reform-next-starter/pull/57/files#diff-007d4a2548702159a27c456e316eaa3925ccc99123279aec8c19fe130436d246).
- Updates the library submodule and GitHub Actions workflow SHAs to commit `087b5f2`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ab3734.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->