### PR TITLE
Add CMS page presentation sentinel

### DIFF
--- a/.github/workflows/call-code-checks.yml
+++ b/.github/workflows/call-code-checks.yml
@@ -3,7 +3,7 @@ on: pull_request
 jobs:
   library:
     # this hash is updated automatically, so if you're resolving a merge conflict, either hash is fine
-    uses: reformcollective/library/.github/workflows/code-checks.yml@087b5f208bc06d936a525df91246215fa732e9d3
+    uses: reformcollective/library/.github/workflows/code-checks.yml@4f7701ab93977dd55d97cd741e3f9870ad1696b6
     secrets:
       SECRETS_JSON: ${{ toJSON(secrets) }}
     with:

--- a/.github/workflows/call-lighthouse.yml
+++ b/.github/workflows/call-lighthouse.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   library:
     # this hash is updated automatically, so if you're resolving a merge conflict, either hash is fine
-    uses: reformcollective/library/.github/workflows/lighthouse.yml@087b5f208bc06d936a525df91246215fa732e9d3
+    uses: reformcollective/library/.github/workflows/lighthouse.yml@4f7701ab93977dd55d97cd741e3f9870ad1696b6
     secrets:
       SECRETS_JSON: ${{ toJSON(secrets) }}
     with:

--- a/app/[[...slug]]/page.tsx
+++ b/app/[[...slug]]/page.tsx
@@ -1,7 +1,10 @@
 import SampleSection from "app/sections/Sample"
 import { EagerImages } from "library/StaticImage"
 import { imageField, linkField, videoField } from "library/sanity/assetMetadata"
-import type { SanityDataAttributeContext } from "library/sanity/getSanityDataAttribute"
+import {
+	getSanityDataAttribute,
+	type SanityDataAttributeContext,
+} from "library/sanity/getSanityDataAttribute"
 import { resolveDocumentTitle, resolveProductionUrl } from "library/sanity/document-helpers"
 import { resolveOpenGraphImage } from "library/sanity/opengraph"
 import { Redirect } from "library/sanity/redirect"
@@ -126,9 +129,21 @@ export default async function TemplatePage({ params }: PageProps<"/[[...slug]]">
 	const sections: PageSection[] = relevantPage.sections
 	if (!pageTitle) notFound()
 
+	const pageDataAttribute = getSanityDataAttribute(
+		{
+			documentId: relevantPage._id,
+			documentType: "page",
+			pathPrefix: "",
+		},
+		"sections",
+	)
+
 	return (
 		<>
 			{relevantPage.noIndex ? <meta name="robots" content="noindex, nofollow" /> : null}
+			{/* Register this page document with Presentation Tool's "Documents on this page" panel.
+			    Without this, pages whose sections have no text (e.g. image-only) are invisible to the panel. */}
+			<div hidden data-sanity={pageDataAttribute} />
 			{sections.map((section, index: number) => {
 				const Wrapper = index === 0 ? EagerImages : Fragment
 


### PR DESCRIPTION
Adds a hidden Sanity page document sentinel to the CMS page route so Presentation Tool can list pages whose sections do not expose text. Updates the library submodule to include the Sanity data attribute helper support for an empty path prefix, and refreshes workflow hashes to that library commit. Validated with `WIREIT_LOGGER=metrics pnpm format`, `WIREIT_LOGGER=metrics pnpm lint`, and `WIREIT_LOGGER=metrics pnpm typecheck`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CMS page presentation sentinel div to `TemplatePage`
> Adds a hidden `<div>` with a `data-sanity` attribute to the `TemplatePage` component in [page.tsx](https://github.com/reformcollective/reform-next-starter/pull/58/files#diff-007d4a2548702159a27c456e316eaa3925ccc99123279aec8c19fe130436d246), computed via `getSanityDataAttribute` using the current page document's id and sections field. This enables Sanity's visual editing overlay to locate the page document in the rendered HTML.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 90ccfe6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->