### PR TITLE
Use f styled utilities

### DIFF
--- a/.github/workflows/call-code-checks.yml
+++ b/.github/workflows/call-code-checks.yml
@@ -3,7 +3,7 @@ on: pull_request
 jobs:
   library:
     # this hash is updated automatically, so if you're resolving a merge conflict, either hash is fine
-    uses: reformcollective/library/.github/workflows/code-checks.yml@ab117bc50c686da2de1269c452c4e91d8fa3325b
+    uses: reformcollective/library/.github/workflows/code-checks.yml@bc86d96381be6c13dade53da0ac42971647c944e
     secrets:
       SECRETS_JSON: ${{ toJSON(secrets) }}
     with:

--- a/.github/workflows/call-lighthouse.yml
+++ b/.github/workflows/call-lighthouse.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   library:
     # this hash is updated automatically, so if you're resolving a merge conflict, either hash is fine
-    uses: reformcollective/library/.github/workflows/lighthouse.yml@ab117bc50c686da2de1269c452c4e91d8fa3325b
+    uses: reformcollective/library/.github/workflows/lighthouse.yml@bc86d96381be6c13dade53da0ac42971647c944e
     secrets:
       SECRETS_JSON: ${{ toJSON(secrets) }}
     with:

--- a/app/(blog-templates)/(blog-template-1)/[blogSlug]/components/Categories.tsx
+++ b/app/(blog-templates)/(blog-template-1)/[blogSlug]/components/Categories.tsx
@@ -17,9 +17,9 @@ export function Categories({ items }: { items: Card[] }) {
 
 	const toggle = (item: string) => {
 		if (categories.includes(item)) {
-			setCategories(categories.filter((c) => c !== item))
+			void setCategories(categories.filter((c) => c !== item))
 		} else {
-			setCategories([...categories, item])
+			void setCategories([...categories, item])
 		}
 	}
 
@@ -30,7 +30,7 @@ export function Categories({ items }: { items: Card[] }) {
 				<Pill
 					type="button"
 					data-selected={categories.length === 0}
-					onClick={() => setCategories(null)}
+					onClick={() => void setCategories(null)}
 				>
 					All
 				</Pill>

--- a/app/(blog-templates)/(blog-template-1)/[blogSlug]/components/FilterState/index.tsx
+++ b/app/(blog-templates)/(blog-template-1)/[blogSlug]/components/FilterState/index.tsx
@@ -17,9 +17,9 @@ export function FilterState() {
 	const isActive = Boolean(query) || hasCategories
 
 	const clearAll = () => {
-		setQuery(null)
-		setCategories(null)
-		setShowAll(null)
+		void setQuery(null)
+		void setCategories(null)
+		void setShowAll(null)
 	}
 
 	const clearLabel =

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,5 +1,5 @@
 import UniversalLink from "library/link"
-import { css, fresponsive, styled } from "library/styled"
+import { css, f, styled } from "library/styled"
 import type { FooterQueryResult } from "sanity.types"
 
 export default function Footer({ footerText }: NonNullable<FooterQueryResult>) {
@@ -22,7 +22,7 @@ export default function Footer({ footerText }: NonNullable<FooterQueryResult>) {
 
 const Wrapper = styled(
 	"footer",
-	fresponsive(css`
+	f.responsive(css`
 		background-color: rebeccapurple;
 		color: white;
 		display: grid;
@@ -36,7 +36,7 @@ const Wrapper = styled(
 
 const Content = styled(
 	"div",
-	fresponsive(css`
+	f.responsive(css`
 		text-align: center;
 		display: flex;
 		flex-direction: column;

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { css, fresponsive, styled } from "library/styled"
+import { css, f, styled } from "library/styled"
 import useAutoHideHeader from "library/useAutoHideHeader"
 import { useRef } from "react"
 import type { HeaderQueryResult } from "sanity.types"
@@ -19,7 +19,7 @@ export default function Header({ headerText }: NonNullable<HeaderQueryResult>) {
 
 const Wrapper = styled(
 	"header",
-	fresponsive(css`
+	f.responsive(css`
 		display: grid;
 		grid-column: fullbleed;
 		grid-row: header;

--- a/app/sample-form/page.tsx
+++ b/app/sample-form/page.tsx
@@ -96,7 +96,8 @@ export default function SampleForm() {
 	const vowelidate = (value: unknown) => {
 		const isEmpty = value === undefined || value === null || value === ""
 		if (isEmpty) return "We need to know your vowels!"
-		const hasVowel = /[aeiouAEIOU]/.test(String(value))
+		if (typeof value !== "string") return "Must contain at least one vowel"
+		const hasVowel = /[aeiouAEIOU]/.test(value)
 		return hasVowel ? null : "Must contain at least one vowel"
 	}
 

--- a/app/styles/project.tsx
+++ b/app/styles/project.tsx
@@ -17,6 +17,7 @@ const style = css`
 	}
 `
 
+// oxlint-disable-next-line typescript-eslint(await-thenable)
 const compiledStyle = await compileTime(() => style)
 
 export const ProjectStyles = () => <style>{compiledStyle}</style>

--- a/app/styles/text.ts
+++ b/app/styles/text.ts
@@ -95,7 +95,7 @@ const textStyles = {
 	 * if you need to add one-off styles, do that here!
 	 */
 	custom: {},
-	// don't wrap these in a fresponsive or unresponsive call!
+	// don't wrap these in an f.responsive or f.unresponsive call!
 	// that should happen at the component level
 	h1: createStyle({
 		fontFamily: geist,

--- a/app/visual-tests/auto-animate/page.tsx
+++ b/app/visual-tests/auto-animate/page.tsx
@@ -2,12 +2,12 @@
 
 import AutoAnimate from "library/AutoAnimate"
 import UniversalLink from "library/link"
-import { css, fresponsive, styled } from "library/styled"
+import { css, f, styled } from "library/styled"
 import { type ComponentProps, Fragment, useEffect, useState } from "react"
 
 const BaseWrapper = styled(
 	AutoAnimate,
-	fresponsive(css`
+	f.responsive(css`
 		outline: 1px solid red;
 	`),
 )
@@ -20,7 +20,7 @@ function Animate(
 
 const OpacityWrapper = styled(
 	AutoAnimate,
-	fresponsive(css`
+	f.responsive(css`
 		outline: 1px solid green;
 	`),
 )
@@ -160,7 +160,7 @@ export default function AutoTests() {
 
 const RestrictWidth = styled(
 	"div",
-	fresponsive(css`
+	f.responsive(css`
 		max-width: 500px;
 		border: 1px solid orange;
 	`),
@@ -168,7 +168,7 @@ const RestrictWidth = styled(
 
 const Wrapper = styled(
 	"div",
-	fresponsive(css`
+	f.responsive(css`
 		display: flex;
 		flex-direction: column;
 		align-items: center;
@@ -179,7 +179,7 @@ const Wrapper = styled(
 
 const Row = styled(
 	"div",
-	fresponsive(css`
+	f.responsive(css`
 		display: flex;
 		min-height: 200px;
 		gap: 40px;
@@ -189,7 +189,7 @@ const Row = styled(
 
 const Tall = styled(
 	"div",
-	fresponsive(css`
+	f.responsive(css`
 		height: 200px;
 		border: 1px solid blue;
 	`),
@@ -197,7 +197,7 @@ const Tall = styled(
 
 const PurpleBox = styled(
 	"div",
-	fresponsive(css`
+	f.responsive(css`
 		border: 1px solid purple;
 	`),
 )

--- a/app/visual-tests/loader/a/page.tsx
+++ b/app/visual-tests/loader/a/page.tsx
@@ -2,7 +2,7 @@
 
 import UniversalLink from "library/link"
 import { loader } from "library/link/loader"
-import { css, fresponsive, styled } from "library/styled"
+import { css, f, styled } from "library/styled"
 import { useEffect, useState } from "react"
 
 export default function Loader() {
@@ -73,7 +73,7 @@ export default function Loader() {
 
 const Wrapper = styled(
 	"div",
-	fresponsive(css`
+	f.responsive(css`
 		display: flex;
 		flex-direction: column;
 		align-items: center;

--- a/app/visual-tests/loader/b/page.tsx
+++ b/app/visual-tests/loader/b/page.tsx
@@ -1,6 +1,6 @@
 import { sleep } from "library/functions"
 import UniversalLink from "library/link"
-import { css, fresponsive, styled } from "library/styled"
+import { css, f, styled } from "library/styled"
 
 export default async function LoaderB() {
 	await sleep(1000)
@@ -31,7 +31,7 @@ export default async function LoaderB() {
 
 const Wrapper = styled(
 	"div",
-	fresponsive(css`
+	f.responsive(css`
 		display: flex;
 		flex-direction: column;
 		align-items: center;

--- a/app/visual-tests/lockers/page.tsx
+++ b/app/visual-tests/lockers/page.tsx
@@ -3,7 +3,7 @@
 import { ScrollSmoother } from "gsap/all"
 import UniversalLink from "library/link"
 import { useScrollLock } from "library/Scroll"
-import { css, styled, unresponsive } from "library/styled"
+import { css, f, styled } from "library/styled"
 import { useState } from "react"
 
 const useScrollLockToggler = (type: "lock" | "unlock") => {
@@ -151,7 +151,7 @@ export default function ScrollLock() {
 
 const Wrapper = styled(
 	"div",
-	unresponsive(css`
+	f.unresponsive(css`
 		display: flex;
 		flex-direction: column;
 		align-items: center;

--- a/app/visual-tests/sticky/page.tsx
+++ b/app/visual-tests/sticky/page.tsx
@@ -2,7 +2,7 @@
 
 import nativeSmoothPin from "library/nativeSmoothPin"
 import UniversalLink from "library/link"
-import { css, fresponsive, styled } from "library/styled"
+import { css, f, styled } from "library/styled"
 
 const sizeOrder: Array<"square" | "100vh" | "120vh"> = ["square", "100vh", "120vh"]
 const topOrder: Array<"zero" | "neg" | "pos"> = ["zero", "neg", "pos"]
@@ -64,7 +64,7 @@ export default function StickyVisualTestPage() {
 
 const Wrapper = styled(
 	"div",
-	fresponsive(css`
+	f.responsive(css`
 		grid-column: main;
 		display: flex;
 		flex-direction: column;
@@ -75,7 +75,7 @@ const Wrapper = styled(
 
 const Group = styled(
 	"div",
-	fresponsive(css`
+	f.responsive(css`
 		display: flex;
 		flex-direction: column;
 		gap: 8px;
@@ -84,7 +84,7 @@ const Group = styled(
 
 const GroupLabel = styled(
 	"div",
-	fresponsive(css`
+	f.responsive(css`
 		font-size: 0.875rem;
 		font-weight: 600;
 		color: #444;
@@ -93,7 +93,7 @@ const GroupLabel = styled(
 
 const Row = styled(
 	"div",
-	fresponsive(css`
+	f.responsive(css`
 		display: grid;
 		grid-template-columns: 1fr 1fr 1fr;
 		gap: 16px;
@@ -102,7 +102,7 @@ const Row = styled(
 
 const StickyColumn = styled(
 	"div",
-	fresponsive(css`
+	f.responsive(css`
 		height: 200vh;
 		display: flex;
 		flex-direction: column;
@@ -115,7 +115,7 @@ const StickyColumn = styled(
 
 const StickyElement = styled("div", {
 	base: [
-		fresponsive(css`
+		f.responsive(css`
 			position: sticky;
 			padding: 16px;
 			background: #e0e0ff;
@@ -152,7 +152,7 @@ const StickyElement = styled("div", {
 			top,
 			goopType,
 			base: [
-				fresponsive(css`
+				f.responsive(css`
           ${
 						top === "neg"
 							? css`


### PR DESCRIPTION
## Summary
- update starter call sites to use f.responsive and f.unresponsive instead of named styled aliases
- update the library submodule pointer to include reformcollective/library#501
- fix validation warnings reported by lint

## Library PR
- https://github.com/reformcollective/library/pull/501

## Validation
- WIREIT_LOGGER=metrics pnpm format
- WIREIT_LOGGER=metrics pnpm typecheck
- WIREIT_LOGGER=metrics pnpm lint
- WIREIT_LOGGER=metrics pnpm build

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `fresponsive` and `unresponsive` imports with `f` utility across styled components
> Replaces direct `fresponsive(...)` and `unresponsive(...)` calls with the namespaced `f.responsive(...)` and `f.unresponsive(...)` equivalents from the updated `library` submodule. Affected files include [Footer.tsx](https://github.com/reformcollective/reform-next-starter/pull/61/files#diff-65edf535b119e7cb1b653d5546abcf5d2f3d35d580ce5d54c63574ba22533862), [Header.tsx](https://github.com/reformcollective/reform-next-starter/pull/61/files#diff-c241ab181629f79a98e7a2e3f1ad045d98962d4c6324c52ddee12578d11bfdae), and several visual test pages. The `library` submodule and CI workflow references are bumped to commit `870558e`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1bb7acd.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->