### PR TITLE
Fix AutoAnimate visual test width

### DIFF
--- a/app/visual-tests/auto-animate/page.tsx
+++ b/app/visual-tests/auto-animate/page.tsx
@@ -169,6 +169,7 @@ const RestrictWidth = styled(
 const Wrapper = styled(
 	"div",
 	fresponsive(css`
+		grid-column: main;
 		display: flex;
 		flex-direction: column;
 		align-items: center;


### PR DESCRIPTION
## Summary
Adds the missing main grid-column placement to the AutoAnimate visual test wrapper so the page uses the intended content width instead of auto-placing into a narrow grid track.

## Validation
- WIREIT_LOGGER=metrics pnpm format
- WIREIT_LOGGER=metrics pnpm typecheck
- WIREIT_LOGGER=metrics pnpm lint
- WIREIT_LOGGER=metrics pnpm build

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix width of AutoAnimate visual test page by adding `grid-column: main`
> Adds `grid-column: main` to the `Wrapper` styled component in [page.tsx](https://github.com/reformcollective/reform-next-starter/pull/62/files#diff-e6c2263718a880614bb07035dae79d51dbaad0bec9ed07db4ff31fba25788c79) so the AutoAnimate visual test page spans the correct grid column width.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84aa18c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->