### PR TITLE
Add Conductor workspace scripts

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,8 @@
+{
+	"scripts": {
+		"setup": "git submodule update --init\nMAIN=$(git worktree list --porcelain | head -1 | awk '{print $2}') && [ \"$(pwd)\" != \"$MAIN\" ] && ln -sf \"$MAIN/.env\" .env\npnpm install",
+		"remoteSetup": "git submodule update --init\nMAIN=$(git worktree list --porcelain | head -1 | awk '{print $2}') && [ \"$(pwd)\" != \"$MAIN\" ] && ln -sf \"$MAIN/.env\" .env\npnpm install",
+		"run": "pnpm dev",
+		"archive": "git submodule deinit --force --all"
+	}
+}


### PR DESCRIPTION
Adds a Conductor workspace configuration for this starter. The scripts initialize submodules, link the main worktree .env when running in a worktree, install dependencies with pnpm, run the dev server, and archive by deinitializing submodules.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Conductor workspace scripts for setup, dev, and archive
> Adds [conductor.json](https://github.com/reformcollective/reform-next-starter/pull/64/files#diff-8f5ff51db30e4376f379b8f2d945a574de23ce745bbf5500864c694e39ef773e) defining four scripts: `setup`/`remoteSetup` initialize git submodules, link `.env` from the primary worktree when running in a secondary worktree, and install dependencies; `run` starts the dev server; `archive` deinitializes all submodules.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc42e8f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->