### PR TITLE
Migrate Sanity live to cache components

### DIFF
--- a/.github/workflows/call-code-checks.yml
+++ b/.github/workflows/call-code-checks.yml
@@ -3,7 +3,7 @@ on: pull_request
 jobs:
   library:
     # this hash is updated automatically, so if you're resolving a merge conflict, either hash is fine
-    uses: reformcollective/library/.github/workflows/code-checks.yml@d6a5632a9e0efa17eee043bde7d9de991fab3a8c
+    uses: reformcollective/library/.github/workflows/code-checks.yml@6c73e7d1e298e43de5d0595a9a6a43d9ca5bb733
     secrets:
       SECRETS_JSON: ${{ toJSON(secrets) }}
     with:

--- a/.github/workflows/call-code-checks.yml
+++ b/.github/workflows/call-code-checks.yml
@@ -3,7 +3,7 @@ on: pull_request
 jobs:
   library:
     # this hash is updated automatically, so if you're resolving a merge conflict, either hash is fine
-    uses: reformcollective/library/.github/workflows/code-checks.yml@870558ed0727f8c83e085a783bfc83adf8498805
+    uses: reformcollective/library/.github/workflows/code-checks.yml@d6a5632a9e0efa17eee043bde7d9de991fab3a8c
     secrets:
       SECRETS_JSON: ${{ toJSON(secrets) }}
     with:

--- a/.github/workflows/call-code-checks.yml
+++ b/.github/workflows/call-code-checks.yml
@@ -3,7 +3,7 @@ on: pull_request
 jobs:
   library:
     # this hash is updated automatically, so if you're resolving a merge conflict, either hash is fine
-    uses: reformcollective/library/.github/workflows/code-checks.yml@6c73e7d1e298e43de5d0595a9a6a43d9ca5bb733
+    uses: reformcollective/library/.github/workflows/code-checks.yml@33b7b8514bfcb27d56e883ba6478c0001bef87c6
     secrets:
       SECRETS_JSON: ${{ toJSON(secrets) }}
     with:

--- a/.github/workflows/call-lighthouse.yml
+++ b/.github/workflows/call-lighthouse.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   library:
     # this hash is updated automatically, so if you're resolving a merge conflict, either hash is fine
-    uses: reformcollective/library/.github/workflows/lighthouse.yml@870558ed0727f8c83e085a783bfc83adf8498805
+    uses: reformcollective/library/.github/workflows/lighthouse.yml@d6a5632a9e0efa17eee043bde7d9de991fab3a8c
     secrets:
       SECRETS_JSON: ${{ toJSON(secrets) }}
     with:

--- a/.github/workflows/call-lighthouse.yml
+++ b/.github/workflows/call-lighthouse.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   library:
     # this hash is updated automatically, so if you're resolving a merge conflict, either hash is fine
-    uses: reformcollective/library/.github/workflows/lighthouse.yml@6c73e7d1e298e43de5d0595a9a6a43d9ca5bb733
+    uses: reformcollective/library/.github/workflows/lighthouse.yml@33b7b8514bfcb27d56e883ba6478c0001bef87c6
     secrets:
       SECRETS_JSON: ${{ toJSON(secrets) }}
     with:

--- a/.github/workflows/call-lighthouse.yml
+++ b/.github/workflows/call-lighthouse.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   library:
     # this hash is updated automatically, so if you're resolving a merge conflict, either hash is fine
-    uses: reformcollective/library/.github/workflows/lighthouse.yml@d6a5632a9e0efa17eee043bde7d9de991fab3a8c
+    uses: reformcollective/library/.github/workflows/lighthouse.yml@6c73e7d1e298e43de5d0595a9a6a43d9ca5bb733
     secrets:
       SECRETS_JSON: ${{ toJSON(secrets) }}
     with:

--- a/app/(blog-templates)/(blog-template-1)/[blogSlug]/(home)/actions.ts
+++ b/app/(blog-templates)/(blog-template-1)/[blogSlug]/(home)/actions.ts
@@ -38,7 +38,11 @@ type PostList = NonNullable<
 
 export async function searchPosts(query: string): Promise<PostList> {
 	if (!query.trim()) {
-		const { data } = await sanityFetch({ query: allPostsServerQuery })
+		const { data } = await sanityFetch({
+			query: allPostsServerQuery,
+			perspective: "published",
+			stega: false,
+		})
 		return data ?? []
 	}
 	// Append * to each term for prefix matching (e.g. "Uta" matches "Utah")
@@ -51,6 +55,8 @@ export async function searchPosts(query: string): Promise<PostList> {
 	const { data } = await sanityFetch({
 		query: searchedPostsQuery,
 		params: { searchQuery: wildcardQuery },
+		perspective: "published",
+		stega: false,
 	})
 	return (data ?? []) as PostList
 }

--- a/app/(blog-templates)/(blog-template-1)/[blogSlug]/(home)/page.tsx
+++ b/app/(blog-templates)/(blog-template-1)/[blogSlug]/(home)/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next"
 
 import { colors } from "app/styles/colors.css"
+import { ensureStaticParams } from "library/next/ensureStaticParams"
 import { imageField } from "library/sanity/assetMetadata"
 import { resolveOpenGraphImage } from "library/sanity/opengraph"
 import { siteURL } from "library/siteURL"
@@ -23,8 +24,7 @@ export async function generateStaticParams() {
 	const data = await sanityFetchStaticParams({
 		query: hubSlugQuery,
 	})
-	if (!data?.slug) return [{ blogSlug: "blog" }]
-	return [{ blogSlug: data.slug }]
+	return ensureStaticParams(data?.slug ? [{ blogSlug: data.slug }] : [], { blogSlug: "blog" })
 }
 
 const allPostsQuery = defineQuery(`

--- a/app/(blog-templates)/(blog-template-1)/[blogSlug]/(home)/page.tsx
+++ b/app/(blog-templates)/(blog-template-1)/[blogSlug]/(home)/page.tsx
@@ -6,21 +6,22 @@ import { resolveOpenGraphImage } from "library/sanity/opengraph"
 import { siteURL } from "library/siteURL"
 import { css, f, styled } from "library/styled"
 import { defineQuery } from "next-sanity"
+import { draftMode } from "next/headers"
 import { Suspense } from "react"
-import { sanityFetch } from "sanity/lib/live"
+import {
+	getDynamicFetchOptions,
+	sanityFetch,
+	sanityFetchStaticParams,
+	type DynamicFetchOptions,
+} from "sanity/lib/live"
 
 import { BlogHomeClient } from "./BlogHomeClient"
-
-export const dynamic = "force-static"
-export const dynamicParams = false
 
 const hubSlugQuery = defineQuery(`*[_type == "blog1Hub"][0]{"slug": slug.current}`)
 
 export async function generateStaticParams() {
-	const { data } = await sanityFetch({
+	const data = await sanityFetchStaticParams({
 		query: hubSlugQuery,
-		perspective: "published",
-		disableStega: true,
 	})
 	if (!data?.slug) return []
 	return [{ blogSlug: data.slug }]
@@ -63,10 +64,8 @@ const blogHubQuery = defineQuery(`
 
 export async function generateMetadata({ params }: PageProps<"/[blogSlug]">): Promise<Metadata> {
 	const { blogSlug } = await params
-	const [{ data: blogHub }, { data: settings }] = await Promise.all([
-		sanityFetch({ query: blogHubQuery, disableStega: true }),
-		sanityFetch({ query: pageSettingsQuery, disableStega: true }),
-	])
+	const { perspective } = await getDynamicFetchOptions()
+	const { blogHub, settings } = await cachedBlogHomeMetadata({ perspective })
 
 	const title = blogHub?.title ?? settings?.defaultTitle
 	const description = blogHub?.description ?? settings?.defaultDescription
@@ -97,11 +96,47 @@ export async function generateMetadata({ params }: PageProps<"/[blogSlug]">): Pr
 	}
 }
 
+async function cachedBlogHomeMetadata({ perspective }: Pick<DynamicFetchOptions, "perspective">) {
+	"use cache"
+
+	const [{ data: blogHub }, { data: settings }] = await Promise.all([
+		sanityFetch({ query: blogHubQuery, perspective, stega: false }),
+		sanityFetch({ query: pageSettingsQuery, perspective, stega: false }),
+	])
+
+	return { blogHub, settings }
+}
+
 export default async function BlogHome() {
-	const { data: blogHub } = await sanityFetch({ query: blogHubQuery, disableStega: true })
+	const { isEnabled: isDraftMode } = await draftMode()
+	if (isDraftMode) {
+		return (
+			<Suspense fallback={<Inner>Loading blog...</Inner>}>
+				<DynamicBlogHome />
+			</Suspense>
+		)
+	}
+
+	return <CachedBlogHome perspective="published" stega={false} />
+}
+
+async function DynamicBlogHome() {
+	const { perspective, stega } = await getDynamicFetchOptions()
+	return <CachedBlogHome perspective={perspective} stega={stega} />
+}
+
+async function CachedBlogHome({
+	perspective,
+	stega,
+}: Pick<DynamicFetchOptions, "perspective" | "stega">) {
+	"use cache"
+
+	const { data: blogHub } = await sanityFetch({ query: blogHubQuery, perspective, stega })
 	const searchMode = blogHub?.searchMode === "server" ? "server" : "client"
 	const { data: allCards } =
-		searchMode === "client" ? await sanityFetch({ query: allPostsQuery }) : { data: [] }
+		searchMode === "client"
+			? await sanityFetch({ query: allPostsQuery, perspective, stega })
+			: { data: [] }
 
 	return (
 		<>

--- a/app/(blog-templates)/(blog-template-1)/[blogSlug]/(home)/page.tsx
+++ b/app/(blog-templates)/(blog-template-1)/[blogSlug]/(home)/page.tsx
@@ -23,7 +23,7 @@ export async function generateStaticParams() {
 	const data = await sanityFetchStaticParams({
 		query: hubSlugQuery,
 	})
-	if (!data?.slug) return []
+	if (!data?.slug) return [{ blogSlug: "blog" }]
 	return [{ blogSlug: data.slug }]
 }
 

--- a/app/(blog-templates)/(blog-template-1)/[blogSlug]/(post)/[slug]/page.tsx
+++ b/app/(blog-templates)/(blog-template-1)/[blogSlug]/(post)/[slug]/page.tsx
@@ -7,11 +7,15 @@ import { resolveOpenGraphImage } from "library/sanity/opengraph"
 import { siteURL } from "library/siteURL"
 import { css, f, styled } from "library/styled"
 import { defineQuery } from "next-sanity"
+import { draftMode } from "next/headers"
 import { notFound } from "next/navigation"
-import { sanityFetch } from "sanity/lib/live"
-
-export const dynamic = "force-static"
-export const dynamicParams = false
+import { Suspense } from "react"
+import {
+	getDynamicFetchOptions,
+	sanityFetch,
+	sanityFetchStaticParams,
+	type DynamicFetchOptions,
+} from "sanity/lib/live"
 
 const postSlugsQuery = defineQuery(`
 	*[_type == "blog1Post" && defined(slug.current)]{"slug": slug.current}
@@ -53,10 +57,8 @@ const singlePostQuery = defineQuery(`
 `)
 
 export async function generateStaticParams() {
-	const { data } = await sanityFetch({
+	const data = await sanityFetchStaticParams({
 		query: postSlugsQuery,
-		perspective: "published",
-		disableStega: true,
 	})
 	return data
 }
@@ -66,7 +68,8 @@ export async function generateMetadata(
 	parent: ResolvingMetadata,
 ): Promise<Metadata> {
 	const { blogSlug, slug } = await params
-	const { data: post } = await sanityFetch({ query: singlePostQuery, params: { slug } })
+	const { perspective } = await getDynamicFetchOptions()
+	const post = await cachedPostMetadata({ slug, perspective })
 
 	const title = post?.title || (await parent).title
 	const description = post?.articleTextPreview || (await parent).description
@@ -93,13 +96,53 @@ export async function generateMetadata(
 	}
 }
 
-export default async function PostPage({ params }: PageProps<"/[blogSlug]/[slug]">) {
-	const { slug } = await params
+async function cachedPostMetadata({
+	slug,
+	perspective,
+}: { slug: string } & Pick<DynamicFetchOptions, "perspective">) {
+	"use cache"
 
 	const { data: post } = await sanityFetch({
 		query: singlePostQuery,
 		params: { slug },
-		disableStega: true,
+		perspective,
+		stega: false,
+	})
+	return post
+}
+
+export default async function PostPage({ params }: PageProps<"/[blogSlug]/[slug]">) {
+	const { isEnabled: isDraftMode } = await draftMode()
+	if (isDraftMode) {
+		return (
+			<Suspense fallback={null}>
+				<DynamicPostPage params={params} />
+			</Suspense>
+		)
+	}
+
+	const { slug } = await params
+	return <CachedPostPage slug={slug} perspective="published" stega={false} />
+}
+
+async function DynamicPostPage({ params }: Pick<PageProps<"/[blogSlug]/[slug]">, "params">) {
+	const { slug } = await params
+	const { perspective, stega } = await getDynamicFetchOptions()
+	return <CachedPostPage slug={slug} perspective={perspective} stega={stega} />
+}
+
+async function CachedPostPage({
+	slug,
+	perspective,
+	stega,
+}: { slug: string } & Pick<DynamicFetchOptions, "perspective" | "stega">) {
+	"use cache"
+
+	const { data: post } = await sanityFetch({
+		query: singlePostQuery,
+		params: { slug },
+		perspective,
+		stega,
 	})
 
 	if (!post) return notFound()

--- a/app/(blog-templates)/(blog-template-1)/[blogSlug]/(post)/[slug]/page.tsx
+++ b/app/(blog-templates)/(blog-template-1)/[blogSlug]/(post)/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata, ResolvingMetadata } from "next"
 
 import PostContent from "app/(blog-templates)/(blog-template-1)/[blogSlug]/components/PostContent"
 import { colors } from "app/styles/colors.css"
+import { ensureStaticParams } from "library/next/ensureStaticParams"
 import { imageField, videoField } from "library/sanity/assetMetadata"
 import { resolveOpenGraphImage } from "library/sanity/opengraph"
 import { siteURL } from "library/siteURL"
@@ -60,9 +61,7 @@ export async function generateStaticParams() {
 	const data = await sanityFetchStaticParams({
 		query: postSlugsQuery,
 	})
-	if (data.length === 0) return [{ slug: "__missing-post__" }]
-
-	return data
+	return ensureStaticParams(data, { slug: "__missing-post__" })
 }
 
 export async function generateMetadata(

--- a/app/(blog-templates)/(blog-template-1)/[blogSlug]/(post)/[slug]/page.tsx
+++ b/app/(blog-templates)/(blog-template-1)/[blogSlug]/(post)/[slug]/page.tsx
@@ -60,6 +60,8 @@ export async function generateStaticParams() {
 	const data = await sanityFetchStaticParams({
 		query: postSlugsQuery,
 	})
+	if (data.length === 0) return [{ slug: "__missing-post__" }]
+
 	return data
 }
 

--- a/app/(sanity)/layout.tsx
+++ b/app/(sanity)/layout.tsx
@@ -1,4 +1,3 @@
-export * from "library/segmentDefaults"
 export { metadata, viewport } from "next-sanity/studio"
 
 export default function RootLayout({ children }: LayoutProps<"/">) {

--- a/app/[[...slug]]/page.tsx
+++ b/app/[[...slug]]/page.tsx
@@ -65,6 +65,8 @@ export async function generateStaticParams() {
 	const data = await sanityFetchStaticParams({
 		query: mainPageSlugsQuery,
 	})
+	if (data.length === 0) return [{ slug: undefined }]
+
 	return data.map((item) => ({
 		slug: item.path === "/" ? undefined : item.path?.replace(/^\/+/, "").split("/"),
 	}))

--- a/app/[[...slug]]/page.tsx
+++ b/app/[[...slug]]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next"
 import type { MainPageQueryResult } from "sanity.types"
 
 import SampleSection from "app/sections/Sample"
+import { ensureStaticParams } from "library/next/ensureStaticParams"
 import { imageField, linkField, videoField } from "library/sanity/assetMetadata"
 import { resolveDocumentTitle, resolveProductionUrl } from "library/sanity/document-helpers"
 import {
@@ -65,9 +66,7 @@ export async function generateStaticParams() {
 	const data = await sanityFetchStaticParams({
 		query: mainPageSlugsQuery,
 	})
-	if (data.length === 0) return [{ slug: undefined }]
-
-	return data.map((item) => ({
+	return ensureStaticParams(data, { _id: "__missing-page__", path: "/" }).map((item) => ({
 		slug: item.path === "/" ? undefined : item.path?.replace(/^\/+/, "").split("/"),
 	}))
 }

--- a/app/[[...slug]]/page.tsx
+++ b/app/[[...slug]]/page.tsx
@@ -13,9 +13,15 @@ import { Redirect } from "library/sanity/redirect"
 import { siteURL } from "library/siteURL"
 import { EagerImages } from "library/StaticImage"
 import { defineQuery } from "next-sanity"
+import { draftMode } from "next/headers"
 import { notFound } from "next/navigation"
-import { Fragment } from "react"
-import { sanityFetch } from "sanity/lib/live"
+import { Fragment, Suspense } from "react"
+import {
+	getDynamicFetchOptions,
+	sanityFetch,
+	sanityFetchStaticParams,
+	type DynamicFetchOptions,
+} from "sanity/lib/live"
 import { documentPathProjection } from "sanity/lib/slug-resolver"
 
 type PageSection = NonNullable<NonNullable<MainPageQueryResult>["sections"]>[number]
@@ -56,10 +62,8 @@ const mainPageSlugsQuery = defineQuery(`
 const mainPageSettingsQuery = defineQuery(`*[_type == "settings"][0]`)
 
 export async function generateStaticParams() {
-	const { data } = await sanityFetch({
+	const data = await sanityFetchStaticParams({
 		query: mainPageSlugsQuery,
-		perspective: "published",
-		disableStega: true,
 	})
 	return data.map((item) => ({
 		slug: item.path === "/" ? undefined : item.path?.replace(/^\/+/, "").split("/"),
@@ -69,18 +73,9 @@ export async function generateStaticParams() {
 export async function generateMetadata({ params }: PageProps<"/[[...slug]]">): Promise<Metadata> {
 	const slug = (await params).slug
 	const pathname = slug ? `/${slug.join("/")}` : "/"
+	const { perspective } = await getDynamicFetchOptions()
 
-	const [{ data: relevantPage }, { data: settings }] = await Promise.all([
-		sanityFetch({
-			query: mainPageQuery,
-			params: { pathname },
-			disableStega: true,
-		}),
-		sanityFetch({
-			query: mainPageSettingsQuery,
-			disableStega: true,
-		}),
-	])
+	const { relevantPage, settings } = await cachedMainPageMetadata({ pathname, perspective })
 
 	const canonicalUrl = resolveProductionUrl(relevantPage)
 	const canonicalTitle = resolveDocumentTitle(relevantPage) || settings?.defaultTitle
@@ -113,14 +108,63 @@ export async function generateMetadata({ params }: PageProps<"/[[...slug]]">): P
 	}
 }
 
-export * from "library/segmentDefaults"
+async function cachedMainPageMetadata({
+	pathname,
+	perspective,
+}: { pathname: string } & Pick<DynamicFetchOptions, "perspective">) {
+	"use cache"
+
+	const [{ data: relevantPage }, { data: settings }] = await Promise.all([
+		sanityFetch({
+			query: mainPageQuery,
+			params: { pathname },
+			perspective,
+			stega: false,
+		}),
+		sanityFetch({
+			query: mainPageSettingsQuery,
+			perspective,
+			stega: false,
+		}),
+	])
+
+	return { relevantPage, settings }
+}
 
 export default async function TemplatePage({ params }: PageProps<"/[[...slug]]">) {
+	const { isEnabled: isDraftMode } = await draftMode()
+	if (isDraftMode) {
+		return (
+			<Suspense fallback={null}>
+				<DynamicTemplatePage params={params} />
+			</Suspense>
+		)
+	}
+
 	const slug = (await params).slug
 	const pathname = slug ? `/${slug.join("/")}` : "/"
+	return <CachedTemplatePage pathname={pathname} perspective="published" stega={false} />
+}
+
+async function DynamicTemplatePage({ params }: Pick<PageProps<"/[[...slug]]">, "params">) {
+	const slug = (await params).slug
+	const pathname = slug ? `/${slug.join("/")}` : "/"
+	const { perspective, stega } = await getDynamicFetchOptions()
+	return <CachedTemplatePage pathname={pathname} perspective={perspective} stega={stega} />
+}
+
+async function CachedTemplatePage({
+	pathname,
+	perspective,
+	stega,
+}: { pathname: string } & Pick<DynamicFetchOptions, "perspective" | "stega">) {
+	"use cache"
+
 	const { data: relevantPage } = await sanityFetch({
 		query: mainPageQuery,
 		params: { pathname },
+		perspective,
+		stega,
 	})
 
 	if (!relevantPage) notFound()

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,8 +10,13 @@ import { siteURL } from "library/siteURL"
 import { css, f, styled } from "library/styled"
 import "app/styles/colors.css"
 import { defineQuery, stegaClean } from "next-sanity"
+import { draftMode } from "next/headers"
 import { Suspense, lazy } from "react"
-import SanityLive, { sanityFetch } from "sanity/lib/live"
+import SanityLive, {
+	getDynamicFetchOptions,
+	sanityFetch,
+	type DynamicFetchOptions,
+} from "sanity/lib/live"
 
 const PageTransition = lazy(() => import("app/components/PageTransition"))
 
@@ -23,12 +28,8 @@ export const metadata: Metadata = {
 	metadataBase: siteURL,
 }
 
-export * from "library/segmentDefaults"
-
 export default async function RootLayout({ children }: LayoutProps<"/">) {
-	const { data: headerData } = await sanityFetch({ query: headerQuery })
-	const { data: footerData } = await sanityFetch({ query: footerQuery })
-	const { data: settings } = await sanityFetch({ query: settingsQuery })
+	const { isEnabled: isDraftMode } = await draftMode()
 
 	return (
 		<html lang="en">
@@ -39,24 +40,93 @@ export default async function RootLayout({ children }: LayoutProps<"/">) {
 						<Suspense>
 							<PageTransition />
 						</Suspense>
-						<SanityLive />
-						{headerData && <Header {...headerData} />}
+						<SanityLive includeDrafts={isDraftMode} />
+						{isDraftMode ? (
+							<Suspense fallback={null}>
+								<DynamicHeader />
+							</Suspense>
+						) : (
+							<CachedHeader perspective="published" stega={false} />
+						)}
 						{children}
-						{footerData && <Footer {...footerData} />}
+						{isDraftMode ? (
+							<Suspense fallback={null}>
+								<DynamicFooter />
+							</Suspense>
+						) : (
+							<CachedFooter perspective="published" stega={false} />
+						)}
 					</PageRoot>
 				</GlobalProviders>
-				{settings?.tags?.map(
-					(tag: { _key: string; embed?: string }) =>
-						tag.embed && (
-							<div
-								key={tag._key}
-								// biome-ignore lint/security/noDangerouslySetInnerHtml: embeds and scripts
-								dangerouslySetInnerHTML={{ __html: stegaClean(tag.embed) }}
-							/>
-						),
+				{isDraftMode ? (
+					<Suspense fallback={null}>
+						<DynamicSettingsTags />
+					</Suspense>
+				) : (
+					<CachedSettingsTags perspective="published" stega={false} />
 				)}
 			</body>
 		</html>
+	)
+}
+
+async function DynamicHeader() {
+	const { perspective, stega } = await getDynamicFetchOptions()
+	return <CachedHeader perspective={perspective} stega={stega} />
+}
+
+async function CachedHeader({
+	perspective,
+	stega,
+}: Pick<DynamicFetchOptions, "perspective" | "stega">) {
+	"use cache"
+	const { data: headerData } = await sanityFetch({ query: headerQuery, perspective, stega })
+	return headerData ? (
+		<Suspense fallback={null}>
+			<Header {...headerData} />
+		</Suspense>
+	) : null
+}
+
+async function DynamicFooter() {
+	const { perspective, stega } = await getDynamicFetchOptions()
+	return <CachedFooter perspective={perspective} stega={stega} />
+}
+
+async function CachedFooter({
+	perspective,
+	stega,
+}: Pick<DynamicFetchOptions, "perspective" | "stega">) {
+	"use cache"
+	const { data: footerData } = await sanityFetch({ query: footerQuery, perspective, stega })
+	return footerData ? (
+		<Suspense fallback={null}>
+			<Footer {...footerData} />
+		</Suspense>
+	) : null
+}
+
+async function DynamicSettingsTags() {
+	const { perspective, stega } = await getDynamicFetchOptions()
+	return <CachedSettingsTags perspective={perspective} stega={stega} />
+}
+
+async function CachedSettingsTags({
+	perspective,
+	stega,
+}: Pick<DynamicFetchOptions, "perspective" | "stega">) {
+	"use cache"
+	const { data: settings } = await sanityFetch({ query: settingsQuery, perspective, stega })
+
+	return settings?.tags?.map(
+		(tag: { _key: string; embed?: string }) =>
+			tag.embed && (
+				<div
+					key={tag._key}
+					// biome-ignore lint/security/noDangerouslySetInnerHtml: embeds and scripts
+					dangerouslySetInnerHTML={{ __html: stegaClean(tag.embed) }}
+				/>
+			),
 	)
 }
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -32,11 +32,17 @@ interface SitemapDocument {
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+	"use cache"
+
 	// 1) File-based static routes
 	const fileRoutes = await listStaticRoutes()
 
 	// 2) CMS routes
-	const { data: cmsDocuments } = await sanityFetch({ query: sitemapCmsQuery })
+	const { data: cmsDocuments } = await sanityFetch({
+		query: sitemapCmsQuery,
+		perspective: "published",
+		stega: false,
+	})
 	const cmsRoutes = cmsDocuments
 		.map((document: SitemapDocument) => document.path)
 		.filter((path): path is string => Boolean(path))

--- a/app/visual-tests/loader/b/page.tsx
+++ b/app/visual-tests/loader/b/page.tsx
@@ -1,8 +1,17 @@
 import { sleep } from "library/functions"
 import UniversalLink from "library/link"
 import { css, f, styled } from "library/styled"
+import { Suspense } from "react"
 
-export default async function LoaderB() {
+export default function LoaderB() {
+	return (
+		<Suspense fallback={null}>
+			<DelayedLoaderB />
+		</Suspense>
+	)
+}
+
+async function DelayedLoaderB() {
 	await sleep(1000)
 
 	return (

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,14 @@
 import type { NextConfig } from "next"
 
+import { sanity } from "next-sanity/live/cache-life"
+
 import { serverSiteURL } from "./library/siteURL/determine"
 import { withVanillaSplit } from "./library/vanilla/withVanillaSplit"
 
 const nextConfig: NextConfig = {
+	cacheComponents: true,
+	cacheLife: { sanity },
+
 	redirects: async () => [{ source: "/home", destination: "/", permanent: false }],
 
 	// we check types manually using tsgo

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"lefthook": "^2.0.15",
 		"lenis": "^1.3.17",
 		"next": "^16.1.5",
-		"next-sanity": "^12.0.14",
+		"next-sanity": "13.0.0-cache-components.57",
 		"nuqs": "^2.8.6",
 		"oxfmt": "^0.44.0",
 		"oxlint": "^1.60.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ importers:
         specifier: ^16.1.5
         version: 16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-sanity:
-        specifier: ^12.0.14
-        version: 12.0.14(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.1)(@sanity/types@5.20.0(@types/react@19.2.14))(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-is@19.2.5)(react@19.2.4)(sanity@5.20.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@oclif/core@4.10.5)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(@types/node@25.0.10)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.3)(jiti@2.6.1)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.1)(ts-toolbelt@9.6.0)(typescript@5.9.3))(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
+        specifier: 13.0.0-cache-components.57
+        version: 13.0.0-cache-components.57(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.1)(@sanity/types@5.20.0(@types/react@19.2.14))(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-is@19.2.5)(react@19.2.4)(sanity@5.20.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@oclif/core@4.10.5)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(@types/node@25.0.10)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.3)(jiti@2.6.1)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.1)(ts-toolbelt@9.6.0)(typescript@5.9.3))(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       nuqs:
         specifier: ^2.8.6
         version: 2.8.6(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
@@ -175,6 +175,9 @@ importers:
       '@vanilla-extract/css':
         specifier: ^1.20.1
         version: 1.20.1(babel-plugin-macros@3.1.0)
+      '@vanilla-extract/dynamic':
+        specifier: ^2
+        version: 2.1.5
       '@vanilla-extract/next-plugin':
         specifier: ^2.5.1
         version: 2.5.2(@swc/helpers@0.5.18)(@types/node@25.5.2)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.31.1)(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.1)(tsx@4.21.0)(webpack@5.106.0)(yaml@2.8.3)
@@ -3316,14 +3319,14 @@ packages:
       '@portabletext/editor': ^6.6.2
       react: ^19.2.4
 
-  '@portabletext/react@6.0.2':
-    resolution: {integrity: sha512-qE3/Fg8PqzGzZ6+lxVXKPDqthJTRG3T1R0R6wrUCVAYeC5e0JtXWwhOiWa0daLG9TEOwn2SUeB2SuWxQlTq+5g==}
+  '@portabletext/react@6.0.3':
+    resolution: {integrity: sha512-xkpykEYKdyR8DJq1oTGKhmwQMqIta8OEHAEMq1EQ5kGOdnVU4ZzU6c+1EZNgyNFpSZs/25ee3kA4Te9ybbQCyA==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
       react: ^19.2.4
 
-  '@portabletext/react@6.0.3':
-    resolution: {integrity: sha512-xkpykEYKdyR8DJq1oTGKhmwQMqIta8OEHAEMq1EQ5kGOdnVU4ZzU6c+1EZNgyNFpSZs/25ee3kA4Te9ybbQCyA==}
+  '@portabletext/react@6.2.0':
+    resolution: {integrity: sha512-Z0J/AWrvg7GyDfEBQRRhi6ZpxLOsN4/QbU8KhTwfa6r2ELiRaMa4gkHE9wfs3V1ozNDrTG4IRr+8yBnHNDnAqA==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
       react: ^19.2.4
@@ -3338,10 +3341,6 @@ packages:
 
   '@portabletext/to-html@5.0.2':
     resolution: {integrity: sha512-w59PcErj5JXUCv9tbV2npqJmcnORTAftCMLp0vc9FnWrXL3C9qYvuB2MQbdHsZEOesF3VmwqUsYUgjm7PX4JTw==}
-    engines: {node: '>=20.19 <22 || >=22.12'}
-
-  '@portabletext/toolkit@5.0.1':
-    resolution: {integrity: sha512-qcwnWd15J2Ziwi0YfWHRx+DRqp87cPb+EBcYuEbDW0ChZwwxCdfIjDazzFpQeXnqhJn8own1c8UB3iHB61DiWg==}
     engines: {node: '>=20.19 <22 || >=22.12'}
 
   '@portabletext/toolkit@5.0.2':
@@ -3831,15 +3830,15 @@ packages:
       react: ^19.2.4
       react-dom: ^19.2.4
 
-  '@sanity/insert-menu@3.0.3':
-    resolution: {integrity: sha512-dp48peOqR6zE73+Uq8bV6gc8MIjrZ8UgkGrsNGMmMQkFCzc1HH1HWkgrRkSRf/Tr/uc9ZYtvU02YHUqMuDh17A==}
+  '@sanity/insert-menu@3.0.4':
+    resolution: {integrity: sha512-90Sky6kraYuoGllbhHe2sYVOHLsRNJCMf/JjjEhsBv5MFNvV7TLIkNeajT4DpI4hMDC0D47d7TYPZJxwAjLP2A==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
       '@sanity/types': '*'
       react: ^19.2.4
 
-  '@sanity/insert-menu@3.0.4':
-    resolution: {integrity: sha512-90Sky6kraYuoGllbhHe2sYVOHLsRNJCMf/JjjEhsBv5MFNvV7TLIkNeajT4DpI4hMDC0D47d7TYPZJxwAjLP2A==}
+  '@sanity/insert-menu@3.0.6':
+    resolution: {integrity: sha512-x0YAqGucktMnFxx0SMSWc+Symn6gcRW1hQ1KevZnoEkbHQFy4stLWlR2W2BuauzJL4H9R5yJQM0ovtb+KIMFZw==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
       '@sanity/types': '*'
@@ -3893,17 +3892,17 @@ packages:
     resolution: {integrity: sha512-D0S2CfVyda99cd/8SnXxQ2tsVlVuRq4CAOjxRuF53evYmBhpWezSEpWKqAa0e1lunGBKK1EroxmOzb5ofNRwMg==}
     engines: {node: '>=20.19 <22 || >=22.12'}
 
-  '@sanity/preview-url-secret@4.0.2':
-    resolution: {integrity: sha512-nl+ad5yDgI8cqkPPBICgkxs4zTF4HDE65L+ATfT2p3MYFrNX/8Dsj70q3AZo/9IuPQhmq2XGXrC52k1EQ3T2zg==}
-    engines: {node: '>=20.19 <22 || >=22.12'}
-    peerDependencies:
-      '@sanity/client': ^7.13.2
-
   '@sanity/preview-url-secret@4.0.4':
     resolution: {integrity: sha512-/xu3OwII4h7hoA9oMVpPIGDfVkKW8xg92dGdN9ofjwEPqgmU8/RJkGYrDrs+LIfmOYzhkslcY9BgecCqQzt3lw==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
       '@sanity/client': ^7.18.0
+
+  '@sanity/preview-url-secret@4.0.6':
+    resolution: {integrity: sha512-Q0Qmag3HaLq1NVWrKw0Ey+N9OFyE4i2tS+1xLDZh5PorFx2JOrFfSwcetGKy1H+gKzQZmDEkc3TlKAOF1K5RDw==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+    peerDependencies:
+      '@sanity/client': ^7.22.0
 
   '@sanity/runtime-cli@14.10.1':
     resolution: {integrity: sha512-oN6O/Nii374UjLN1cSroJauE8uO0cFR1CmNt2LUQvI0xZ+sEvnEvcqmi8AwNeC9aY0mNJ2JYJ6lvKIk0fYFFkg==}
@@ -3982,11 +3981,11 @@ packages:
       sanity: ^4.0.0-0 || ^5.0.0-0
       styled-components: ^6.1.15
 
-  '@sanity/visual-editing-csm@3.0.4':
-    resolution: {integrity: sha512-ZZX3TMmNgSYAnampagpqUFaV62TfV4isEd7THJNd3jEe6OwXUsVFFmfJIWgcOvolWW6XR54CLb75qCFHfTKouQ==}
+  '@sanity/visual-editing-csm@3.0.8':
+    resolution: {integrity: sha512-YzESUeUz/LA1ICW5bMl39PSUmLsQUqPEQpqF9JTmp6APV3n5WJgExDEmRfq9INUNUpJAfSXAFQT+OFnycOVKwA==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
-      '@sanity/client': ^7.13.2
+      '@sanity/client': ^7.22.0
 
   '@sanity/visual-editing-types@1.1.8':
     resolution: {integrity: sha512-4Hu3J8qDLanymnSapRzKwHlQl6SCsBbkL1o5fSMVbWVHvTk/j2uGLLNTsjASICTqUwSm3fwWlyahzCy2uS/LvQ==}
@@ -3998,21 +3997,21 @@ packages:
       '@sanity/types':
         optional: true
 
-  '@sanity/visual-editing-types@2.0.3':
-    resolution: {integrity: sha512-5EJX5aHanbR4wdMZk7N5+WZ6icVW7wTvTf6yxuM1oKAvmO38qFf+Ucc4EUiBlduc1rAANpV3Bdi0HQMEzJHdbQ==}
+  '@sanity/visual-editing-types@2.0.7':
+    resolution: {integrity: sha512-W9SbxubSjJ+5E9DeqIjKdkQT+MFFHqDcImhDKvdMhoTH5B+szGdPAHe5U/jIMNotiT6GQq/eitKaW3bPl8CgvQ==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
-      '@sanity/client': ^7.13.2
+      '@sanity/client': ^7.22.0
       '@sanity/types': '*'
     peerDependenciesMeta:
       '@sanity/types':
         optional: true
 
-  '@sanity/visual-editing@5.1.1':
-    resolution: {integrity: sha512-QyV4m0j2Wjo0M87R6rUPXMl9IgCS5VUok8yV9YY6OX4LAQy3iKyPfw0R2Xjd+1vkU2G47crJsqo6yEGR3WEvYA==}
+  '@sanity/visual-editing@5.3.4':
+    resolution: {integrity: sha512-pdbx9f3C8x9BVnjb4EfLtK5v/LMTV6VlAT/m1o7k81vlocsyzbGhTwoyjoILy5t2TF9uLVfBXqCtFIKNA53sew==}
     engines: {node: '>=20.19'}
     peerDependencies:
-      '@sanity/client': ^7.13.2
+      '@sanity/client': ^7.21.0
       '@sveltejs/kit': '>= 2'
       next: '>=16.0.0-0'
       react: ^19.2.4
@@ -4031,6 +4030,10 @@ packages:
         optional: true
       svelte:
         optional: true
+
+  '@sanity/webhook@4.0.4':
+    resolution: {integrity: sha512-c8LmzR5Wx93zJ10ohhp0XlmPrTNSFyvPcLbNY/sN45Wj5VOngz4FbBMbX9j64sSQLt+676U6OhiVfjs1yw3YCw==}
+    engines: {node: '>=20.0.0'}
 
   '@sanity/worker-channels@2.0.0':
     resolution: {integrity: sha512-mC+8yPQuw2rHXdHigFPU9thNa6vTaPmh7jFR6RvloE8s+6dmnk9bHdPXRbrrUqafxzK3L9aH2E170ubXyxcAIA==}
@@ -5069,9 +5072,6 @@ packages:
 
   '@vercel/frameworks@3.21.1':
     resolution: {integrity: sha512-N8ciri8NSz4vlc8Dqfa9cr1rn2RRbmG3T8Q+8/QM/4af4d1UbSdBG8cBBo7jQSQfNobjURRGL/miGBe+dS2wOQ==}
-
-  '@vercel/stega@1.0.0':
-    resolution: {integrity: sha512-jyDUZEBjxmlh28J4y2wB6dBKayYOw1+9fRNRHWRN2oSO+LnooRHUe2z3JeTkCqXY2yrZ9dmtCl982YNIoIBeuw==}
 
   '@vercel/stega@1.1.0':
     resolution: {integrity: sha512-DFOm3Gk78nKDkppQEG5aj8Wj8R8hPKu/xrz4Rtp0AfiaNbZNCoJbxn7VI6iMxqhGeLdUDy/8mTuTWMz/izAtPA==}
@@ -6860,8 +6860,8 @@ packages:
     resolution: {integrity: sha512-BvrBoRFr4Jmb2HB4kKO3IsP9+u2+D+WH2nA0pGsNVQMN/P1P2PuHbNB/LUuDD9y4+YWYiPRftLl0Hc6D+y8Irw==}
     engines: {node: '>=20.19 <22 || >=22.12'}
 
-  groq@5.6.0:
-    resolution: {integrity: sha512-CNI1dRPMX1dVv8Mfp+U7J/zq9mxXRhc5pXtAgXMHxPWnp6grCSN8ivmZWIKqGW587zbYBUWrKJzBjaVLK8dHdw==}
+  groq@5.25.0:
+    resolution: {integrity: sha512-+BgeZ38DGbycfEmP1B4TDGan/qH7X/Mr5gQnuBKcjQ6ptmUSFMMu28NUktrJnQ3jISur3drI2+w969yWrk7CzQ==}
     engines: {node: '>=20.19 <22 || >=22.12'}
 
   gsap@3.14.2:
@@ -8079,15 +8079,15 @@ packages:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
 
-  next-sanity@12.0.14:
-    resolution: {integrity: sha512-yh2Y4oGmn79fZD0KzLK8LMd/oNb8zDGYG9oRy5xQpGNzEfbZPNSl+/Fi8LeP+jEGOcjbgAbBxuQRaCJBWPoukQ==}
+  next-sanity@13.0.0-cache-components.57:
+    resolution: {integrity: sha512-19H6G9OdbhIi+rVU56eHVmuq4Aayg8VeGm4C6f8QXgAPNCz8zQ9E0WCWqSe1hGlulqtO9Pub6baCkZpSSpXM8g==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     peerDependencies:
-      '@sanity/client': ^7.14.0
+      '@sanity/client': ^7.22.0
       next: ^16.0.0-0
       react: ^19.2.4
       react-dom: ^19.2.4
-      sanity: ^5.5.0
+      sanity: ^5.24.0
       styled-components: ^6.1
 
   next@16.1.5:
@@ -8888,9 +8888,6 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-
-  react-is@19.2.4:
-    resolution: {integrity: sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==}
 
   react-is@19.2.5:
     resolution: {integrity: sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==}
@@ -14519,13 +14516,13 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@portabletext/react@6.0.2(react@19.2.4)':
+  '@portabletext/react@6.0.3(react@19.2.4)':
     dependencies:
-      '@portabletext/toolkit': 5.0.1
-      '@portabletext/types': 4.0.1
+      '@portabletext/toolkit': 5.0.2
+      '@portabletext/types': 4.0.2
       react: 19.2.4
 
-  '@portabletext/react@6.0.3(react@19.2.4)':
+  '@portabletext/react@6.2.0(react@19.2.4)':
     dependencies:
       '@portabletext/toolkit': 5.0.2
       '@portabletext/types': 4.0.2
@@ -14546,10 +14543,6 @@ snapshots:
     dependencies:
       '@portabletext/toolkit': 5.0.2
       '@portabletext/types': 4.0.2
-
-  '@portabletext/toolkit@5.0.1':
-    dependencies:
-      '@portabletext/types': 4.0.1
 
   '@portabletext/toolkit@5.0.2':
     dependencies:
@@ -15128,20 +15121,20 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@sanity/insert-menu@3.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.20.0(@types/react@19.2.14))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@sanity/insert-menu@3.0.4(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.20.0(@types/react@19.2.14))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@sanity/icons': 3.7.4(react@19.2.4)
       '@sanity/types': 5.20.0(@types/react@19.2.14)
-      '@sanity/ui': 3.1.11(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
-      lodash-es: 4.17.23
+      '@sanity/ui': 3.1.14(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.5)(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      lodash-es: 4.18.1
       react: 19.2.4
-      react-is: 19.2.4
+      react-is: 19.2.5
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - react-dom
       - styled-components
 
-  '@sanity/insert-menu@3.0.4(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.20.0(@types/react@19.2.14))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@sanity/insert-menu@3.0.6(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.20.0(@types/react@19.2.14))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@sanity/icons': 3.7.4(react@19.2.4)
       '@sanity/types': 5.20.0(@types/react@19.2.14)
@@ -15218,21 +15211,6 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@sanity/mutate@0.16.1(xstate@5.25.1)':
-    dependencies:
-      '@sanity/client': 7.14.1(debug@4.4.3)
-      '@sanity/diff-match-patch': 3.2.0
-      '@sanity/uuid': 3.0.2
-      hotscript: 1.0.13
-      lodash: 4.17.23
-      mendoza: 3.0.8
-      nanoid: 5.1.7
-      rxjs: 7.8.2
-    optionalDependencies:
-      xstate: 5.25.1
-    transitivePeerDependencies:
-      - debug
-
   '@sanity/mutator@5.20.0(@types/react@19.2.14)':
     dependencies:
       '@sanity/diff-match-patch': 3.2.0
@@ -15260,14 +15238,14 @@ snapshots:
       - '@sanity/client'
       - '@sanity/types'
 
-  '@sanity/preview-url-secret@4.0.2(@sanity/client@7.14.1)':
-    dependencies:
-      '@sanity/client': 7.14.1(debug@4.4.3)
-      '@sanity/uuid': 3.0.2
-
   '@sanity/preview-url-secret@4.0.4(@sanity/client@7.20.0)':
     dependencies:
       '@sanity/client': 7.20.0
+      '@sanity/uuid': 3.0.2
+
+  '@sanity/preview-url-secret@4.0.6(@sanity/client@7.14.1)':
+    dependencies:
+      '@sanity/client': 7.14.1(debug@4.4.3)
       '@sanity/uuid': 3.0.2
 
   '@sanity/runtime-cli@14.10.1(@types/node@25.0.10)(lightningcss@1.31.1)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)':
@@ -15400,24 +15378,6 @@ snapshots:
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
 
-  '@sanity/ui@3.1.11(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
-    dependencies:
-      '@floating-ui/react-dom': 2.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@juggle/resize-observer': 3.4.0
-      '@sanity/color': 3.0.6
-      '@sanity/icons': 3.7.4(react@19.2.4)
-      csstype: 3.2.3
-      motion: 12.29.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      react: 19.2.4
-      react-compiler-runtime: 1.0.0(react@19.2.4)
-      react-dom: 19.2.4(react@19.2.4)
-      react-is: 19.2.4
-      react-refractor: 4.0.0(react@19.2.4)
-      styled-components: 6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      use-effect-event: 2.0.3(react@19.2.4)
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-
   '@sanity/ui@3.1.11(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.5)(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@floating-ui/react-dom': 2.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -15508,10 +15468,10 @@ snapshots:
       - react-dom
       - react-is
 
-  '@sanity/visual-editing-csm@3.0.4(@sanity/client@7.14.1)(@sanity/types@5.20.0(@types/react@19.2.14))(typescript@5.9.3)':
+  '@sanity/visual-editing-csm@3.0.8(@sanity/client@7.14.1)(@sanity/types@5.20.0(@types/react@19.2.14))(typescript@5.9.3)':
     dependencies:
       '@sanity/client': 7.14.1(debug@4.4.3)
-      '@sanity/visual-editing-types': 2.0.3(@sanity/client@7.14.1)(@sanity/types@5.20.0(@types/react@19.2.14))
+      '@sanity/visual-editing-types': 2.0.7(@sanity/client@7.14.1)(@sanity/types@5.20.0(@types/react@19.2.14))
       valibot: 1.2.0(typescript@5.9.3)
     transitivePeerDependencies:
       - '@sanity/types'
@@ -15529,29 +15489,30 @@ snapshots:
     optionalDependencies:
       '@sanity/types': 5.20.0(@types/react@19.2.14)
 
-  '@sanity/visual-editing-types@2.0.3(@sanity/client@7.14.1)(@sanity/types@5.20.0(@types/react@19.2.14))':
+  '@sanity/visual-editing-types@2.0.7(@sanity/client@7.14.1)(@sanity/types@5.20.0(@types/react@19.2.14))':
     dependencies:
       '@sanity/client': 7.14.1(debug@4.4.3)
     optionalDependencies:
       '@sanity/types': 5.20.0(@types/react@19.2.14)
 
-  '@sanity/visual-editing@5.1.1(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.1)(@sanity/types@5.20.0(@types/react@19.2.14))(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-is@19.2.5)(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
+  '@sanity/visual-editing@5.3.4(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.1)(@sanity/types@5.20.0(@types/react@19.2.14))(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-is@19.2.5)(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
     dependencies:
       '@sanity/comlink': 4.0.1
       '@sanity/icons': 3.7.4(react@19.2.4)
-      '@sanity/insert-menu': 3.0.3(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.20.0(@types/react@19.2.14))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
-      '@sanity/mutate': 0.16.1(xstate@5.25.1)
+      '@sanity/insert-menu': 3.0.6(@emotion/is-prop-valid@1.4.0)(@sanity/types@5.20.0(@types/react@19.2.14))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@sanity/mutate': 0.16.1(debug@4.4.3)(xstate@5.30.0)
       '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.14.1)(@sanity/types@5.20.0(@types/react@19.2.14))
-      '@sanity/preview-url-secret': 4.0.2(@sanity/client@7.14.1)
-      '@sanity/ui': 3.1.11(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.5)(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
-      '@sanity/visual-editing-csm': 3.0.4(@sanity/client@7.14.1)(@sanity/types@5.20.0(@types/react@19.2.14))(typescript@5.9.3)
-      '@vercel/stega': 1.0.0
+      '@sanity/preview-url-secret': 4.0.6(@sanity/client@7.14.1)
+      '@sanity/ui': 3.1.14(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.5)(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@sanity/visual-editing-csm': 3.0.8(@sanity/client@7.14.1)(@sanity/types@5.20.0(@types/react@19.2.14))(typescript@5.9.3)
+      '@vercel/stega': 1.1.0
+      dequal: 2.0.3
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       rxjs: 7.8.2
       scroll-into-view-if-needed: 3.1.0
       styled-components: 6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      xstate: 5.25.1
+      xstate: 5.30.0
     optionalDependencies:
       '@sanity/client': 7.14.1(debug@4.4.3)
       next: 16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -15561,6 +15522,8 @@ snapshots:
       - debug
       - react-is
       - typescript
+
+  '@sanity/webhook@4.0.4': {}
 
   '@sanity/worker-channels@2.0.0': {}
 
@@ -16893,8 +16856,6 @@ snapshots:
       '@iarna/toml': 2.2.3
       '@vercel/error-utils': 2.0.3
       js-yaml: 3.13.1
-
-  '@vercel/stega@1.0.0': {}
 
   '@vercel/stega@1.1.0': {}
 
@@ -18890,7 +18851,7 @@ snapshots:
 
   groq@5.20.0: {}
 
-  groq@5.6.0: {}
+  groq@5.25.0: {}
 
   gsap@3.14.2: {}
 
@@ -20068,22 +20029,20 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next-sanity@12.0.14(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.1)(@sanity/types@5.20.0(@types/react@19.2.14))(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-is@19.2.5)(react@19.2.4)(sanity@5.20.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@oclif/core@4.10.5)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(@types/node@25.0.10)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.3)(jiti@2.6.1)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.1)(ts-toolbelt@9.6.0)(typescript@5.9.3))(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3):
+  next-sanity@13.0.0-cache-components.57(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.1)(@sanity/types@5.20.0(@types/react@19.2.14))(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-is@19.2.5)(react@19.2.4)(sanity@5.20.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@oclif/core@4.10.5)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(@types/node@25.0.10)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.3)(jiti@2.6.1)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.1)(ts-toolbelt@9.6.0)(typescript@5.9.3))(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3):
     dependencies:
-      '@portabletext/react': 6.0.2(react@19.2.4)
+      '@portabletext/react': 6.2.0(react@19.2.4)
       '@sanity/client': 7.14.1(debug@4.4.3)
-      '@sanity/comlink': 4.0.1
-      '@sanity/presentation-comlink': 2.0.1(@sanity/client@7.14.1)(@sanity/types@5.20.0(@types/react@19.2.14))
-      '@sanity/preview-url-secret': 4.0.2(@sanity/client@7.14.1)
-      '@sanity/visual-editing': 5.1.1(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.1)(@sanity/types@5.20.0(@types/react@19.2.14))(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-is@19.2.5)(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
-      dequal: 2.0.3
-      groq: 5.6.0
+      '@sanity/generate-help-url': 4.0.0
+      '@sanity/preview-url-secret': 4.0.6(@sanity/client@7.14.1)
+      '@sanity/visual-editing': 5.3.4(@emotion/is-prop-valid@1.4.0)(@sanity/client@7.14.1)(@sanity/types@5.20.0(@types/react@19.2.14))(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-is@19.2.5)(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
+      '@sanity/webhook': 4.0.4
+      groq: 5.25.0
       history: 5.3.0
       next: 16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       sanity: 5.20.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@oclif/core@4.10.5)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@25.0.10)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.1)(yaml@2.8.3))(@types/node@25.0.10)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.3)(jiti@2.6.1)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.1)(ts-toolbelt@9.6.0)(typescript@5.9.3)
-      server-only: 0.0.1
       styled-components: 6.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
@@ -20895,8 +20854,6 @@ snapshots:
       typescript: 5.9.3
 
   react-is@16.13.1: {}
-
-  react-is@19.2.4: {}
 
   react-is@19.2.5: {}
 

--- a/sanity/lib/live.ts
+++ b/sanity/lib/live.ts
@@ -1,7 +1,45 @@
-import {
-	LibraryLive as SanityLive,
-	libraryFetch as sanityFetch,
-} from "library/sanity/reusableFetch"
+import { type QueryParams } from "next-sanity"
+import { defineLive, resolvePerspectiveFromCookies, type LivePerspective } from "next-sanity/live"
+import { cookies, draftMode } from "next/headers"
+import { client } from "sanity/lib/client"
+import { token } from "sanity/lib/token"
 
-export { sanityFetch }
+export interface DynamicFetchOptions {
+	perspective: LivePerspective
+	stega: boolean
+	isDraftMode: boolean
+}
+
+export const { sanityFetch, SanityLive } = defineLive({
+	client,
+	serverToken: token,
+	browserToken: token,
+	strict: true,
+})
+
+export async function getDynamicFetchOptions(): Promise<DynamicFetchOptions> {
+	const { isEnabled: isDraftMode } = await draftMode()
+	if (!isDraftMode) {
+		return { perspective: "published", stega: false, isDraftMode }
+	}
+
+	const jar = await cookies()
+	const perspective = await resolvePerspectiveFromCookies({ cookies: jar })
+	return { perspective: perspective ?? "drafts", stega: true, isDraftMode }
+}
+
+export async function sanityFetchStaticParams<const QueryString extends string>({
+	query,
+	params = {},
+}: {
+	query: QueryString
+	params?: QueryParams
+}) {
+	return client.fetch(query, params, {
+		perspective: "published",
+		stega: false,
+		useCdn: true,
+	})
+}
+
 export default SanityLive


### PR DESCRIPTION
## Summary
- enable Next cacheComponents with Sanity cache life
- move Sanity live setup to strict next-sanity cache-components APIs
- migrate Sanity-backed routes to explicit perspective/stega and cached fetch boundaries
- update the library submodule to the next-sanity cache-components compatibility branch

## Related
- Depends on reformcollective/library#510

## Validation
- WIREIT_LOGGER=metrics pnpm format
- WIREIT_LOGGER=metrics pnpm typecheck
- WIREIT_LOGGER=metrics pnpm lint
- WIREIT_LOGGER=metrics pnpm build

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate Sanity live data fetching to Next.js cache components
> - Introduces `"use cache"` cached components for all major page types (main pages, blog home, post pages, layout header/footer/settings) so published content is served from cache without re-fetching on every request.
> - Adds draft mode gating throughout: in draft mode, pages render Suspense-wrapped dynamic components that resolve perspective and stega via `getDynamicFetchOptions`; otherwise they render the cached published variants.
> - Adds `sanityFetchStaticParams` helper in [`sanity/lib/live.ts`](https://github.com/reformcollective/reform-next-starter/pull/65/files#diff-39d73e8faf1e235ae90afd105f2923a5add974419bfedc2e174e7b2157e1fa38) that fetches with `perspective: "published"` and stega disabled for `generateStaticParams` calls.
> - Enables `cacheComponents: true` in [`next.config.ts`](https://github.com/reformcollective/reform-next-starter/pull/65/files#diff-e3f38f2f0e7ba92f0dd56c086ec5de704229d58d5371e8cc57e43961757d8c7b) and sets Sanity-specific cache lifetime via `next-sanity/live/cache-life`.
> - Updates `next-sanity` to `13.0.0-cache-components.57` to support the new cache component APIs.
> - Behavioral Change: `SanityLive` now conditionally includes drafts based on draft mode, and all data fetching paths explicitly set `stega: false` for non-draft renders.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 902ef49. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->