### PR TITLE
Fix Wireit cache inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,9 +114,29 @@
 		"generate-manifest": {
 			"command": "mkdir -p public/studio && sanity manifest extract --path public/studio/static",
 			"files": [
+				".env",
+				"app/env.ts",
+				"library/**/*.ts",
+				"library/**/*.tsx",
 				"sanity/**/*",
-				"sanity.config.ts"
+				"sanity.config.ts",
+				"sanity.cli.ts",
+				"tsconfig.json"
 			],
+			"env": {
+				"NEXT_PUBLIC_SANITY_DATASET": {
+					"external": true
+				},
+				"NEXT_PUBLIC_SANITY_PROJECT_ID": {
+					"external": true
+				},
+				"NODE_ENV": {
+					"external": true
+				},
+				"SANITY_AUTH_TOKEN": {
+					"external": true
+				}
+			},
 			"output": [
 				"public/studio/static/**/*"
 			]
@@ -124,14 +144,34 @@
 		"sanity-typegen": {
 			"command": "(sanity schema extract && sanity typegen generate) || (pnpm exec sanity schema validate)",
 			"files": [
+				".env",
 				"sanity/**/*",
 				"sanity.config.ts",
+				"sanity.cli.ts",
+				"tsconfig.json",
 				"app/**/*.ts",
 				"app/**/*.tsx",
+				"app/**/*.js",
+				"app/**/*.jsx",
 				"library/**/*.ts",
 				"library/**/*.tsx",
-				"sanity.cli.ts"
+				"library/**/*.js",
+				"library/**/*.jsx"
 			],
+			"env": {
+				"NEXT_PUBLIC_SANITY_DATASET": {
+					"external": true
+				},
+				"NEXT_PUBLIC_SANITY_PROJECT_ID": {
+					"external": true
+				},
+				"NODE_ENV": {
+					"external": true
+				},
+				"SANITY_AUTH_TOKEN": {
+					"external": true
+				}
+			},
 			"output": [
 				"schema.json",
 				"sanity.types.ts"
@@ -142,11 +182,14 @@
 			"files": [
 				"app/**/*.ts",
 				"app/**/*.tsx",
+				"library/siteURL/**/*.ts",
+				"library/vanilla/**/*.ts",
 				"next.config.ts",
 				"tsconfig.json"
 			],
 			"output": [
-				".next/types/**/*.ts"
+				".next/types/**/*.ts",
+				"next-env.d.ts"
 			]
 		},
 		"typegen": {


### PR DESCRIPTION
Fixes stale Wireit cache keys for generated Sanity and Next artifacts. The manifest and Sanity typegen tasks now track the env/config/source files they actually read, including external Sanity env vars. Next typegen now declares next-env.d.ts as an output so cache restore includes all generated files. Validated with format, typecheck, lint, build, and a follow-up typegen cache restore check.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Wireit cache inputs in `package.json` to include missing source and config files
> Expands the file-glob arrays and env declarations used by Wireit to correctly track cache inputs.
>
> - Adds `.env`, `sanity.cli.ts`, `tsconfig.json`, and `app/**` / `library/**` TypeScript and JavaScript globs to relevant build step input lists
> - Marks `NEXT_PUBLIC_SANITY_DATASET`, `NEXT_PUBLIC_SANITY_PROJECT_ID`, `NODE_ENV`, and `SANITY_AUTH_TOKEN` as `{ external: true }` env vars in the affected Wireit configs
> - Adds `library/siteURL/**/*.ts`, `library/vanilla/**/*.ts`, and `next-env.d.ts` to TypeScript-related input paths
> - Behavioral Change: Wireit will now invalidate its cache when any of these previously-untracked files or env vars change, causing previously-skipped steps to re-run
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 48c20d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->