### PR TITLE
Add configurable metadata titles

### DIFF
--- a/app/(blog-templates)/(blog-template-1)/[blogSlug]/(home)/page.tsx
+++ b/app/(blog-templates)/(blog-template-1)/[blogSlug]/(home)/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next"
 
+import { resolveMetaTitle } from "app/lib/metadata"
 import { colors } from "app/styles/colors.css"
 import { imageField } from "library/sanity/assetMetadata"
 import { resolveOpenGraphImage } from "library/sanity/opengraph"
@@ -44,6 +45,7 @@ const pageSettingsQuery = defineQuery(`*[_type == "settings"][0]`)
 const blogHubQuery = defineQuery(`
 	*[_type == "blog1Hub"][0] {
 		title,
+		metaTitle,
 		description,
 		noIndex,
 		searchMode,
@@ -68,7 +70,11 @@ export async function generateMetadata({ params }: PageProps<"/[blogSlug]">): Pr
 		sanityFetch({ query: pageSettingsQuery, disableStega: true }),
 	])
 
-	const title = blogHub?.title ?? settings?.defaultTitle
+	const title = resolveMetaTitle({
+		title: blogHub?.metaTitle || blogHub?.title,
+		separator: settings?.metaTitleSeparator,
+		suffix: settings?.defaultTitle,
+	})
 	const description = blogHub?.description ?? settings?.defaultDescription
 	const image = blogHub?.ogImage
 		? resolveOpenGraphImage(blogHub.ogImage)

--- a/app/(blog-templates)/(blog-template-1)/[blogSlug]/(post)/[slug]/page.tsx
+++ b/app/(blog-templates)/(blog-template-1)/[blogSlug]/(post)/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, ResolvingMetadata } from "next"
 
 import PostContent from "app/(blog-templates)/(blog-template-1)/[blogSlug]/components/PostContent"
+import { resolveMetaTitle } from "app/lib/metadata"
 import { colors } from "app/styles/colors.css"
 import { imageField, videoField } from "library/sanity/assetMetadata"
 import { resolveOpenGraphImage } from "library/sanity/opengraph"
@@ -32,6 +33,7 @@ const singlePostQuery = defineQuery(`
 	*[_type == "blog1Post" && slug.current == $slug][0] {
 		_id,
 		title,
+		metaTitle,
 		"slug": slug.current,
 		"author": author-> {
 			name,
@@ -67,14 +69,19 @@ export async function generateMetadata(
 ): Promise<Metadata> {
 	const { blogSlug, slug } = await params
 	const { data: post } = await sanityFetch({ query: singlePostQuery, params: { slug } })
+	const parentMetadata = await parent
+	const parentTitle = typeof parentMetadata.title === "string" ? parentMetadata.title : undefined
 
-	const title = post?.title || (await parent).title
-	const description = post?.articleTextPreview || (await parent).description
+	const title = resolveMetaTitle({
+		title: post?.metaTitle || post?.title,
+		suffix: parentTitle,
+	})
+	const description = post?.articleTextPreview || parentMetadata.description
 	const imageData = post?.mainImage && resolveOpenGraphImage(post?.mainImage)
 	const newImage = imageData ? [imageData] : undefined
 
-	const opengraph = newImage ?? (await parent).openGraph?.images
-	const twitter = newImage ?? (await parent).twitter?.images
+	const opengraph = newImage ?? parentMetadata.openGraph?.images
+	const twitter = newImage ?? parentMetadata.twitter?.images
 
 	return {
 		title,

--- a/app/[[...slug]]/page.tsx
+++ b/app/[[...slug]]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next"
 import type { MainPageQueryResult } from "sanity.types"
 
+import { resolveMetaTitle } from "app/lib/metadata"
 import SampleSection from "app/sections/Sample"
 import { imageField, linkField, videoField } from "library/sanity/assetMetadata"
 import { resolveDocumentTitle, resolveProductionUrl } from "library/sanity/document-helpers"
@@ -33,6 +34,7 @@ export type GetSectionType<T extends SectionTypes> = WithExtraProps<
 const mainPageQuery = defineQuery(`
 	*[${documentPathProjection("@")} == $pathname][0] {
 		...,
+		metaTitle,
 		description,
 		ogImage,
 		sections[] {
@@ -83,7 +85,11 @@ export async function generateMetadata({ params }: PageProps<"/[[...slug]]">): P
 	])
 
 	const canonicalUrl = resolveProductionUrl(relevantPage)
-	const canonicalTitle = resolveDocumentTitle(relevantPage) || settings?.defaultTitle
+	const canonicalTitle = resolveMetaTitle({
+		title: relevantPage?.metaTitle || resolveDocumentTitle(relevantPage),
+		separator: settings?.metaTitleSeparator,
+		suffix: settings?.defaultTitle,
+	})
 	const canonicalDescription = relevantPage?.description || settings?.defaultDescription
 
 	const image = relevantPage?.ogImage

--- a/app/lib/metadata.ts
+++ b/app/lib/metadata.ts
@@ -1,0 +1,17 @@
+export function resolveMetaTitle({
+	separator,
+	suffix,
+	title,
+}: {
+	separator?: string | null
+	suffix?: string | null
+	title?: string | null
+}) {
+	const cleanTitle = title?.trim()
+	const cleanSuffix = suffix?.trim()
+
+	if (!cleanTitle) return cleanSuffix
+	if (!cleanSuffix || cleanTitle === cleanSuffix) return cleanTitle
+
+	return `${cleanTitle} ${separator?.trim() || "|"} ${cleanSuffix}`
+}

--- a/sanity/schemas/blog/blog-1/postType.ts
+++ b/sanity/schemas/blog/blog-1/postType.ts
@@ -34,6 +34,12 @@ export const blog1PostType = defineType({
 				"A short description of the article. Used on the blog hub page and at the top of the article. Supports line breaks.",
 			validation: (Rule) => Rule.required(),
 		}),
+		defineField({
+			name: "metaTitle",
+			title: "Meta Title",
+			type: "string",
+			description: "Optional. Overrides the page title used in browser tabs and search results.",
+		}),
 		{
 			...universalImage({ name: "mainImage", title: "Main Image" }),
 		},

--- a/sanity/schemas/sanityPage.tsx
+++ b/sanity/schemas/sanityPage.tsx
@@ -88,6 +88,12 @@ export const pageMetadata = [
 			}),
 	}),
 	defineField({
+		name: "metaTitle",
+		title: "Meta Title",
+		type: "string",
+		description: "Optional. Overrides the page title used in browser tabs and search results.",
+	}),
+	defineField({
 		name: "description",
 		title: "Page Description",
 		type: "string",

--- a/sanity/schemas/singletons/blog-1.tsx
+++ b/sanity/schemas/singletons/blog-1.tsx
@@ -42,6 +42,12 @@ export const blog1Hub = defineType({
 			description:
 				"Leave blank to reuse the default, defined in Settings. This will be used when shared on socials, and by some search engines.",
 		}),
+		defineField({
+			name: "metaTitle",
+			title: "Meta Title",
+			type: "string",
+			description: "Optional. Overrides the page title used in browser tabs and search results.",
+		}),
 		universalImage({
 			name: "ogImage",
 			title: "Open Graph Image",

--- a/sanity/schemas/singletons/settings.tsx
+++ b/sanity/schemas/singletons/settings.tsx
@@ -10,8 +10,24 @@ export default defineType({
 	fields: [
 		defineField({
 			name: "defaultTitle",
-			title: "Default Page Title",
+			title: "Title Suffix",
 			type: "string",
+			description: "Added after page-specific titles in browser tabs and search results.",
+		}),
+		defineField({
+			name: "metaTitleSeparator",
+			title: "Title Separator",
+			type: "string",
+			description: "Placed between the page title and title suffix.",
+			initialValue: "|",
+			options: {
+				list: [
+					{ title: "|", value: "|" },
+					{ title: "-", value: "-" },
+					{ title: ":", value: ":" },
+				],
+				layout: "radio",
+			},
 		}),
 		defineField({
 			name: "defaultDescription",


### PR DESCRIPTION
Adds optional meta title fields for standard pages, blog hubs, and blog posts. Adds settings for a title suffix and separator, then uses a shared helper to compose metadata titles consistently. Updates page and blog metadata generation to prefer explicit meta titles while preserving existing description and image fallbacks.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable metadata titles with per-page overrides and separator settings
> - Adds a `metaTitle` field to Sanity schemas for pages, blog posts, and the blog hub, allowing per-document override of the browser/search tab title.
> - Adds a `metaTitleSeparator` field to the settings singleton (defaulting to `|`) and renames `defaultTitle` to 'Title Suffix', which is appended to all composed titles.
> - Introduces [`resolveMetaTitle`](https://github.com/reformcollective/reform-next-starter/pull/69/files#diff-bf9b5e85083996212090a26000de14e98a0c1c48bdf6ebeb5afd0e18e43cc08d) to consistently compose titles from an optional page-level title, separator, and suffix across all page types.
> - Updates `generateMetadata` in all three page routes to use `resolveMetaTitle` instead of the previous simple fallback logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 103d4d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->