### PR TITLE
Copy pasta section

### DIFF
--- a/app/sections/PageSectionTemplate.tsx
+++ b/app/sections/PageSectionTemplate.tsx
@@ -1,0 +1,47 @@
+// import type { GetSectionType } from "page"
+
+// import { colors } from "app/styles/colors.css"
+// import textStyles from "app/styles/text"
+import { css, f, styled } from "library/styled"
+
+export default function PageSection() {
+	return (
+		<Wrapper>
+			<Inner />
+		</Wrapper>
+	)
+}
+
+/**
+ * spans the full width of the page and re-declares the page grid,
+ * so that children can use `grid-column: main` (or any other column)
+ */
+const Wrapper = styled("div", [
+	f.unresponsive(css`
+		grid-column: fullbleed;
+		grid-template-columns: var(--subgrid-columns);
+		position: relative;
+		display: grid;
+		align-items: center;
+		overflow: hidden;
+	`),
+])
+
+/**
+ * `main` caps and centers itself — no `max-width` or `margin: 0 auto` needed here.
+ *
+ * the grid brackets `main` with `calc((100vw - sourceDesignWidth) / 2)` spacer tracks
+ * (see `library/layoutGridBuilder.tsx`). those px go through the same responsive
+ * conversion as everything else, so inside the fluid ranges they resolve to exactly
+ * 0 — the whole grid is scaling in vw and there is nothing to cap. past the top
+ * breakpoint the px pin instead, the spacers grow, and `main` stops at ~1601px.
+ *
+ * you *would* need a max-width if this project set `scaleFully: true`, or if this
+ * element sat on `fullbleed` / `scaled-main` instead of `main`.
+ */
+const Inner = styled("div", [
+	f.responsive(css`
+		grid-column: main;
+		border: 1px solid black;
+	`),
+])

--- a/app/sections/PageSectionTemplate.tsx
+++ b/app/sections/PageSectionTemplate.tsx
@@ -42,6 +42,5 @@ const Wrapper = styled("div", [
 const Inner = styled("div", [
 	f.responsive(css`
 		grid-column: main;
-		border: 1px solid black;
 	`),
 ])

--- a/app/visual-tests/page-section-template/page.tsx
+++ b/app/visual-tests/page-section-template/page.tsx
@@ -1,0 +1,203 @@
+import PageSection from "app/sections/PageSectionTemplate"
+import UniversalLink from "library/link"
+import { css, f, styled } from "library/styled"
+
+/**
+ * everything below `Nav` is a hardcoded copy-paste of
+ * `app/sections/PageSectionTemplate.tsx` — that's the thing being tested.
+ */
+
+export default function PageSectionTemplateTests() {
+	return (
+		<>
+			<Nav>
+				<h1>Page Section Template Tests</h1>
+				<UniversalLink href="/visual-tests">← visual tests</UniversalLink>
+				<Note>
+					the <code>Wrapper</code> / <code>Inner</code> pair below is a hardcoded copy-paste of{" "}
+					<strong>app/sections/PageSectionTemplate.tsx</strong>, with content dropped in. Its
+					wrapper should run edge to edge, while its content lines up with this text and with the
+					header and footer.
+				</Note>
+
+				<Note>
+					<strong>why there is no max-width on the inner element.</strong> the page grid brackets{" "}
+					<code>main</code> with <code>calc((100vw - sourceDesignWidth) / 2)</code> spacer tracks (
+					<code>library/layoutGridBuilder.tsx</code>). those px run through the same responsive
+					conversion as every other px, so what they resolve to depends on the breakpoint — and{" "}
+					<code>main</code> ends up capping and centering itself at every size. resize the window
+					and watch the bordered edges below:
+				</Note>
+
+				<Table>
+					<tbody>
+						<tr>
+							<th>mobile ≤700</th>
+							<td>
+								<code>375px</code> → <code>100vw</code>
+							</td>
+							<td>spacers 0</td>
+							<td>fluid, full margin-to-margin</td>
+						</tr>
+						<tr>
+							<th>tablet 701–1024</th>
+							<td>
+								<code>375px</code> → <code>701px</code>
+							</td>
+							<td>
+								<code>(100vw - 701px) / 2</code>
+							</td>
+							<td>capped 701px, centered</td>
+						</tr>
+						<tr>
+							<th>desktop 1025–1600</th>
+							<td>
+								<code>1440px</code> → <code>100vw</code>
+							</td>
+							<td>spacers 0</td>
+							<td>fluid, full margin-to-margin</td>
+						</tr>
+						<tr>
+							<th>fullWidth ≥1601</th>
+							<td>
+								<code>1440px</code> → <code>1601px</code>
+							</td>
+							<td>
+								<code>(100vw - 1601px) / 2</code>
+							</td>
+							<td>capped 1601px, centered</td>
+						</tr>
+					</tbody>
+				</Table>
+
+				<Note>
+					this holds because <code>app/libraryConfig.ts</code> sets <code>scaleFully: false</code> —
+					that&rsquo;s what makes px pin above 1600 and the spacer tracks grow. flip it to{" "}
+					<code>true</code> and nothing caps <code>main</code> anymore, at which point a max-width
+					becomes real. same if you put content on <code>fullbleed</code> or{" "}
+					<code>scaled-main</code> instead of <code>main</code>.
+				</Note>
+			</Nav>
+
+			<Marker>↑ this text is on `main` — everything below should line up with it</Marker>
+
+			<Wrapper>
+				<Inner>
+					<h2>Wrapper + Inner</h2>
+					<p>
+						the scaffold, copy-pasted and filled in. the wrapper is fullbleed and re-declares the
+						page grid; this inner element sits on `grid-column: main`.
+					</p>
+				</Inner>
+			</Wrapper>
+
+			<TintedWrapper>
+				<Inner>
+					<h2>Wrapper + Inner, tinted</h2>
+					<p>
+						same scaffold with a background on the wrapper, so you can see it bleed past both edges
+						of the viewport while the content stays on `main`.
+					</p>
+				</Inner>
+			</TintedWrapper>
+
+			<Marker>↓ the bare template import, unmodified</Marker>
+
+			<PageSection />
+
+			<Nav>
+				<p>
+					the bare template renders an empty `Inner`, so it collapses to no height — if there's a
+					border on it you'll see a thin line above, otherwise nothing. that's expected.
+				</p>
+			</Nav>
+		</>
+	)
+}
+
+const Nav = styled("div", [
+	f.responsive(css`
+		grid-column: main;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 16px;
+		padding: 48px 0;
+	`),
+])
+
+const Note = styled("p", [
+	f.responsive(css`
+		max-width: 640px;
+		padding: 16px;
+		border: 1px solid black;
+		background: #ffd;
+	`),
+])
+
+const Table = styled("table", [
+	f.responsive(css`
+		border-collapse: collapse;
+		text-align: left;
+
+		th,
+		td {
+			padding: 4px 16px 4px 0;
+			vertical-align: top;
+			white-space: nowrap;
+		}
+	`),
+])
+
+const Marker = styled("p", [
+	f.responsive(css`
+		grid-column: main;
+		padding: 8px 0;
+		color: #c00;
+	`),
+])
+
+/* ------------------------------------------------------------------------- */
+/* copy-pasted from app/sections/PageSectionTemplate.tsx                       */
+/* ------------------------------------------------------------------------- */
+
+/**
+ * spans the full width of the page and re-declares the page grid,
+ * so that children can use `grid-column: main` (or any other column)
+ */
+const Wrapper = styled("div", [
+	f.unresponsive(css`
+		grid-column: fullbleed;
+		grid-template-columns: var(--subgrid-columns);
+		position: relative;
+		display: grid;
+		align-items: center;
+		overflow: hidden;
+	`),
+])
+
+/** `main` is already centered and constrained to the design width */
+const Inner = styled("div", [
+	f.responsive(css`
+		grid-column: main;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 16px;
+		padding: 96px 0;
+	`),
+	f.small(css`
+		padding: 48px 0;
+	`),
+])
+
+const TintedWrapper = styled(Wrapper, [
+	f.unresponsive(css`
+		background: #def;
+
+		> div {
+			background: tomato;
+			padding: 14px;
+		}
+	`),
+])


### PR DESCRIPTION
Adds a copy-pasteable starting point for new page sections, plus a visual test for it.

## `app/sections/PageSectionTemplate.tsx`

Just the two pieces that are identical in every section: a `Wrapper` on `grid-column: fullbleed` that re-declares `--subgrid-columns`, and an `Inner` on `grid-column: main`. Copy the file, rename it, fill it in. `Sample.tsx` already covers what a filled-in section looks like, so this stays empty on purpose.

The `GetSectionType`, `colors`, and `textStyles` imports ship commented out. `GetSectionType<"yourSection">` can't resolve until the schema exists, is exported from `sanity/schemas/sections/index.ts`, and typegen has run — so it can't ship uncommented without breaking a fresh clone.

## Why there's no `max-width` on `Inner`

This is the part that isn't obvious, and it's written into the file as a comment.

The page grid brackets `main` with `calc((100vw - sourceDesignWidth) / 2)` spacer tracks (`library/layoutGridBuilder.tsx`). Those px go through the same responsive conversion as every other px in the declaration, including the design width itself — so what they resolve to depends on the breakpoint:

| breakpoint | design width becomes | spacer track | `main` |
|---|---|---|---|
| mobile ≤700 | `375px` → `100vw` | 0 | fluid, margin-to-margin |
| tablet 701–1024 | `375px` → `701px` | `(100vw - 701px) / 2` | capped 701px, centered |
| desktop 1025–1600 | `1440px` → `100vw` | 0 | fluid, margin-to-margin |
| fullWidth ≥1601 | `1440px` → `1601px` | `(100vw - 1601px) / 2` | capped 1601px, centered |

So `main` caps and centers itself at every size, and adding `max-width: 1440px; margin: 0 auto` on top of it fights the grid rather than helping.

This depends on `scaleFully: false` in `app/libraryConfig.ts` — that's what makes px pin above 1600 instead of staying fluid. Flip it to `true` and nothing caps `main` anymore, at which point a max-width becomes real. Same if content sits on `fullbleed` or `scaled-main` instead of `main`.

## `app/visual-tests/page-section-template/page.tsx`

Hardcoded, no Sanity content needed. Renders a `Wrapper` / `Inner` pair copy-pasted straight from the template (same names, so it's obvious which is which), a tinted variant so you can see the wrapper bleed past both edges while content stays on `main`, and the bare template imported directly. Reference markers on `main` above and below to check alignment, plus the breakpoint table above rendered on the page so you can resize and watch it behave.

## Testing

`pnpm format`, `pnpm lint`, and a full `tsgo --noEmit` typecheck all clean. Visit `/visual-tests/page-section-template`.
